### PR TITLE
refactor naming

### DIFF
--- a/target/idl/lb_clmm.json
+++ b/target/idl/lb_clmm.json
@@ -2415,7 +2415,7 @@
           {
             "name": "maxSwappedAmount",
             "docs": [
-              "Max X swapped amount user can swap from y to x between activation_slot and last_sloi"
+              "Max X swapped amount user can swap from y to x between activation_slot and last_slot"
             ],
             "type": "u64"
           },

--- a/target/types/lb_clmm.ts
+++ b/target/types/lb_clmm.ts
@@ -2415,7 +2415,7 @@ export type LbClmm = {
           {
             "name": "maxSwappedAmount",
             "docs": [
-              "Max X swapped amount user can swap from y to x between activation_slot and last_sloi"
+              "Max X swapped amount user can swap from y to x between activation_slot and last_slot"
             ],
             "type": "u64"
           },
@@ -6869,7 +6869,7 @@ export const IDL: LbClmm = {
           {
             "name": "maxSwappedAmount",
             "docs": [
-              "Max X swapped amount user can swap from y to x between activation_slot and last_sloi"
+              "Max X swapped amount user can swap from y to x between activation_slot and last_slot"
             ],
             "type": "u64"
           },

--- a/ts-client/src/dlmm/helpers/binArray.ts
+++ b/ts-client/src/dlmm/helpers/binArray.ts
@@ -7,7 +7,7 @@ import {
   BinArrayAccount,
   BinArrayBitmapExtension,
   BitmapType,
-  LbPairAccount,
+  LbPair,
 } from "../types";
 import {
   EXTENSION_BINARRAY_BITMAP_SIZE,
@@ -182,7 +182,7 @@ export function getBinFromBinArray(binId: number, binArray: BinArray): Bin {
 export function findNextBinArrayIndexWithLiquidity(
   swapForY: boolean,
   activeId: BN,
-  lbPairState: LbPairAccount,
+  lbPairState: LbPair,
   binArrayBitmapExtension: BinArrayBitmapExtension | null
 ): BN | null {
   const [lowerBinArrayIndex, upperBinArrayIndex] = internalBitmapRange();
@@ -293,7 +293,7 @@ export function findNextBinArrayIndexWithLiquidity(
 export function findNextBinArrayWithLiquidity(
   swapForY: boolean,
   activeBinId: BN,
-  lbPairState: LbPairAccount,
+  lbPairState: LbPair,
   binArrayBitmapExtension: BinArrayBitmapExtension,
   binArrays: BinArrayAccount[]
 ): BinArrayAccount | null {

--- a/ts-client/src/dlmm/index.ts
+++ b/ts-client/src/dlmm/index.ts
@@ -25,8 +25,8 @@ import {
 import {
   BinLiquidity,
   ClmmProgram,
+  LbPair,
   LbPairAccount,
-  LbPairAccountsStruct,
   PositionAccount,
   PositionBinData,
   PositionData,
@@ -98,12 +98,12 @@ export class DLMM {
   constructor(
     public pubkey: PublicKey,
     public program: ClmmProgram,
-    public lbPair: LbPairAccount,
+    public lbPair: LbPair,
     public binArrayBitmapExtension: BinArrayBitmapExtensionAccount | null,
     public tokenX: TokenReserve,
     public tokenY: TokenReserve,
     private opt?: Opt
-  ) {}
+  ) { }
 
   /** Static public method */
 
@@ -115,12 +115,12 @@ export class DLMM {
    * @param {Opt} [opt] - The `opt` parameter is an optional object that contains additional options
    * for the function. It can have the following properties:
    * @returns The function `getLbPairs` returns a Promise that resolves to an array of
-   * `LbPairAccountsStruct` objects.
+   * `LbPairAccount` objects.
    */
   public static async getLbPairs(
     connection: Connection,
     opt?: Opt
-  ): Promise<LbPairAccountsStruct[]> {
+  ): Promise<LbPairAccount[]> {
     const provider = new AnchorProvider(
       connection,
       {} as any,
@@ -171,7 +171,7 @@ export class DLMM {
     const lbPairAccountInfoBuffer = accountsInfo[0]?.data;
     if (!lbPairAccountInfoBuffer)
       throw new Error(`LB Pair account ${dlmm.toBase58()} not found`);
-    const lbPairAccInfo: LbPairAccount = program.coder.accounts.decode(
+    const lbPairAccInfo: LbPair = program.coder.accounts.decode(
       "lbPair",
       lbPairAccountInfoBuffer
     );
@@ -258,7 +258,7 @@ export class DLMM {
       accountsToFetch
     );
 
-    const lbPairArraysMap = new Map<string, LbPairAccount>();
+    const lbPairArraysMap = new Map<string, LbPair>();
     for (let i = 0; i < dlmmList.length; i++) {
       const lbPairPubKey = dlmmList[i];
       const lbPairAccountInfoBuffer = accountsInfo[i]?.data;
@@ -508,13 +508,13 @@ export class DLMM {
       let i = binArrayPubkeyArray.length + lbPairArray.length;
       i <
       binArrayPubkeyArray.length +
-        lbPairArray.length +
-        binArrayPubkeyArrayV2.length;
+      lbPairArray.length +
+      binArrayPubkeyArrayV2.length;
       i++
     ) {
       const binArrayPubkey =
         binArrayPubkeyArrayV2[
-          i - (binArrayPubkeyArray.length + lbPairArray.length)
+        i - (binArrayPubkeyArray.length + lbPairArray.length)
         ];
       const binArrayAccInfoBufferV2 = binArraysAccInfo[i];
       if (!binArrayAccInfoBufferV2)
@@ -539,10 +539,10 @@ export class DLMM {
     ) {
       const lbPairPubkey =
         lbPairArrayV2[
-          i -
-            (binArrayPubkeyArray.length +
-              lbPairArray.length +
-              binArrayPubkeyArrayV2.length)
+        i -
+        (binArrayPubkeyArray.length +
+          lbPairArray.length +
+          binArrayPubkeyArrayV2.length)
         ];
       const lbPairAccInfoBufferV2 = binArraysAccInfo[i];
       if (!lbPairAccInfoBufferV2)
@@ -614,7 +614,7 @@ export class DLMM {
       string,
       {
         publicKey: PublicKey;
-        lbPair: LbPairAccount;
+        lbPair: LbPair;
         tokenX: TokenReserve;
         tokenY: TokenReserve;
         lbPairPositionsData: Array<{
@@ -2814,7 +2814,7 @@ export class DLMM {
   private static async getClaimableLMReward(
     program: ClmmProgram,
     positionVersion: PositionVersion,
-    lbPair: LbPairAccount,
+    lbPair: LbPair,
     onChainTimestamp: number,
     position: PositionAccount,
     lowerBinArray?: BinArray,
@@ -2995,7 +2995,7 @@ export class DLMM {
   private static async processPosition(
     program: ClmmProgram,
     version: PositionVersion,
-    lbPair: LbPairAccount,
+    lbPair: LbPair,
     onChainTimestamp: number,
     positionAccount: PositionAccount,
     baseTokenDecimal: number,
@@ -3097,7 +3097,7 @@ export class DLMM {
   }
 
   private static getBinsBetweenLowerAndUpperBound(
-    lbPair: LbPairAccount,
+    lbPair: LbPair,
     lowerBinId: number,
     upperBinId: number,
     baseTokenDecimal: number,
@@ -3363,7 +3363,7 @@ export class DLMM {
       if (elapsed < sParameter.decayPeriod) {
         const decayedVolatilityReference = Math.floor(
           (vParameter.volatilityAccumulator * sParameter.reductionFactor) /
-            BASIS_POINT_MAX
+          BASIS_POINT_MAX
         );
         vParameter.volatilityReference = decayedVolatilityReference;
       } else {

--- a/ts-client/src/dlmm/types/index.ts
+++ b/ts-client/src/dlmm/types/index.ts
@@ -31,8 +31,8 @@ export interface TokenReserve {
 
 export type ClmmProgram = Program<LbClmm>;
 
-export type LbPairAccount = IdlAccounts<LbClmm>["lbPair"];
-export type LbPairAccountsStruct = ProgramAccount<
+export type LbPair = IdlAccounts<LbClmm>["lbPair"];
+export type LbPairAccount = ProgramAccount<
   IdlAccounts<LbClmm>["lbPair"]
 >;
 
@@ -68,7 +68,7 @@ export interface Position {
 
 export interface PositionInfo {
   publicKey: PublicKey;
-  lbPair: LbPairAccount;
+  lbPair: LbPair;
   tokenX: TokenReserve;
   tokenY: TokenReserve;
   lbPairPositionsData: Array<Position>;
@@ -164,7 +164,7 @@ export interface SwapQuote {
 
 export interface IAccountsCache {
   binArrays: Map<String, BinArray>;
-  lbPair: LbPairAccount;
+  lbPair: LbPair;
 }
 
 export interface PositionBinData {


### PR DESCRIPTION
Right now there is inconsistent in naming for structs:
Ex: we call
```
export type BinArray = IdlAccounts<LbClmm>["binArray"];
export type BinArrayAccount = ProgramAccount<IdlAccounts<LbClmm>["binArray"]>;
```
But in Lb pair we use
```
export type LbPairAccount = IdlAccounts<LbClmm>["lbPair"];
export type LbPairAccountsStruct = ProgramAccount<
  IdlAccounts<LbClmm>["lbPair"]
>;
```

So the PR helps naming convention, remove the confusion 