### PR TITLE
Update multiple pools call in the docs from `create` to `createMultiple`.

### DIFF
--- a/ts-client/README.md
+++ b/ts-client/README.md
@@ -32,7 +32,7 @@ const USDC_USDT_POOL = new PublicKey('ARwi1S4DaiTG5DX7S4M4ZsrXqpMD1MrTmbu9ue2tpm
 const dlmmPool = await DLMM.create(connection, USDC_USDT_POOL);
 
 // If you need to create multiple, can consider using `createMultiple`
-const dlmmPool = await DLMM.create(connection, [USDC_USDT_POOL, ...]);
+const dlmmPool = await DLMM.createMultiple(connection, [USDC_USDT_POOL, ...]);
 
 ```
 


### PR DESCRIPTION
Just noticed this copy/paste typo in the docs while setting up a multiple pool connection. Easy fix!