### PR TITLE
feat: expose initialize bin array and helper to get bin arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+## @meteora-ag/dlmm [1.0.51] - PR #94
+
+### Added
+
+- `getBinArraysRequiredByPositionRange`. Retrieves the bin arrays required to initialize multiple positions in continuous range.
+- `initializeBinArrays`. Initializes bin arrays for the given bin array indexes if it wasn't initialized.
+
 ## @meteora-ag/dlmm [1.0.50] - PR #91
 
 ### Changed
@@ -39,7 +46,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Exclude positions without any fees and/or rewards from reward claims in the `claimAllRewards` method.
 
-
 ## @meteora-ag/dlmm [1.0.46] - PR #84
 
 ### Added
@@ -52,14 +58,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Renamed `swapQuoteAtBin` function to `swapExactInQuoteAtBin`
 
-
 ## lb_clmm [0.7.0] - PR #84
 
 ### Added
 
 - Program endpoint `swap_exact_out`. It will consume the in amount until the exact out amount reached.
 - Program endpoint `swap_with_price_impact`. Similar to minimum amount out (slippage), but in price impact form.
-
 
 ## common [0.1.1] - PR #84
 
@@ -70,7 +74,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Breaking
 
 - Renamed return type of `swap_exact_in` function, `SwapQuote` to `SwapExactInQuote`
-
 
 ## @meteora-ag/dlmm [1.0.45] - PR #76
 
@@ -84,13 +87,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - fix `addLiquidityByStrategy` not working when active bin is not within the liquidity
 
-
 ## commons [0.1.0] - PR #80
 
 ### Added
 
 - Swap exact in quote
-
 
 ## @meteora-ag/dlmm [1.0.44] - PR #81
 
@@ -98,13 +99,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `getEmissionRate` should not return ended reward, which can be read from `rewardDurationEnd`
 
-
 ## @meteora-ag/dlmm [1.0.43] - PR #76
 
 ### Changed
 
 - update static function to support param program id
-
 
 ## lb_clmm [0.6.1] - PR #79
 
@@ -112,13 +111,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Staging program id
 
-
 ## @meteora-ag/dlmm [1.0.42] - PR #78
 
 ### Fixed
 
 - `swapQuote` not working on pool with bitmap extension when in token is tokenX
-
 
 ## @meteora-ag/dlmm [1.0.41] - PR #77
 
@@ -126,13 +123,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `swapQuote` not working on pool with bitmap extension
 
-
 ## @meteora-ag/dlmm [1.0.40] - PR #74
 
 ### Added
 
 - `getMaxPriceInBinArrays` to get the max price of a bin that has liquidity
-
 
 ## lb_clmm [0.6.0] - PR #75
 
@@ -149,13 +144,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Reduced whitelisted_wallet from the size of 2 to 1. This break the `update_whitelisted_wallet` endpoint.
 
-
 ## @meteora-ag/dlmm [1.0.38] - PR #71
 
 ### Added
 
 - `getTokensMintFromPoolAddress` helper function to get tokenX mint & tokenY mint from lb pair address
-
 
 ## @meteora-ag/dlmm [1.0.37] - PR #68
 
@@ -173,7 +166,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `getPairPubkeyIfExists` function to get the public key of existing pool address, if the pool doesn't exists return null
 
-
 ## @meteora-ag/dlmm [1.0.35] - PR #59
 
 ### Added
@@ -185,13 +177,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `findSwappableMinMaxBinId` returned invalid min/max bin id under some edge case
 - `derivePosition` using invalid seed
 
-
 ## lb_clmm [0.5.2] - PR #59
 
 ### Added
 
 - Add deposit single sided with exact amount endpoint
-
 
 ## lb_clmm [0.5.1] - PR #49
 
@@ -209,7 +199,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Initialization of `LbPair` PDA require `base_factor` as the fourth seed now. This break `InitializeLbPair` account context.
 - Initialization of `PresetParameter` PDA require `base_factor` as the third seed now. This break `InitializePresetParameter` account context.
 
-
 ## @meteora-ag/dlmm [1.0.34] - PR #49
 
 ### Features
@@ -221,20 +210,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `deriveLbPair` no longer in use. Use `deriveLbPair2` for new pair PDA.
 - `derivePresetParameter` no longer in use. Use `derivePresetParameter2` for new preset parameter PDA.
 
-
 ## @mercurial-finance/dynamic-amm-sdk [1.0.33] - PR #67
 
 ### Fixed
 
 - Fix position liquidity withdraw to position owner, instead of customized fee owner
 
-
 ## @mercurial-finance/dynamic-amm-sdk [1.0.32] - PR #58
 
 ### Added
 
 - A new function to sync outdated pool to nearest market price bin
-
 
 ## @mercurial-finance/dlmm-sdk [1.0.30] - PR #65
 
@@ -245,7 +231,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Fixed
 
 - Fix position quotation calculation for bin array creation.
-
 
 ## @mercurial-finance/dlmm-sdk [1.0.27] - PR #57
 

--- a/ts-client/package.json
+++ b/ts-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meteora-ag/dlmm",
-  "version": "1.0.50",
+  "version": "1.0.51",
   "description": "",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/ts-client/src/dlmm/index.ts
+++ b/ts-client/src/dlmm/index.ts
@@ -133,7 +133,7 @@ export class DLMM {
     public tokenX: TokenReserve,
     public tokenY: TokenReserve,
     private opt?: Opt
-  ) { }
+  ) {}
 
   /** Static public method */
 
@@ -427,7 +427,7 @@ export class DLMM {
           reserveAndTokenMintAccountsInfo[reservePublicKeys.length + index * 2];
         const tokenYMintAccountInfo =
           reserveAndTokenMintAccountsInfo[
-          reservePublicKeys.length + index * 2 + 1
+            reservePublicKeys.length + index * 2 + 1
           ];
 
         if (!reserveXAccountInfo || !reserveYAccountInfo)
@@ -643,13 +643,13 @@ export class DLMM {
       let i = binArrayPubkeyArray.length + lbPairArray.length;
       i <
       binArrayPubkeyArray.length +
-      lbPairArray.length +
-      binArrayPubkeyArrayV2.length;
+        lbPairArray.length +
+        binArrayPubkeyArrayV2.length;
       i++
     ) {
       const binArrayPubkey =
         binArrayPubkeyArrayV2[
-        i - (binArrayPubkeyArray.length + lbPairArray.length)
+          i - (binArrayPubkeyArray.length + lbPairArray.length)
         ];
       const binArrayAccInfoBufferV2 = binArraysAccInfo[i];
       if (!binArrayAccInfoBufferV2)
@@ -674,10 +674,10 @@ export class DLMM {
     ) {
       const lbPairPubkey =
         lbPairArrayV2[
-        i -
-        (binArrayPubkeyArray.length +
-          lbPairArray.length +
-          binArrayPubkeyArrayV2.length)
+          i -
+            (binArrayPubkeyArray.length +
+              lbPairArray.length +
+              binArrayPubkeyArrayV2.length)
         ];
       const lbPairAccInfoBufferV2 = binArraysAccInfo[i];
       if (!lbPairAccInfoBufferV2)
@@ -1614,35 +1614,35 @@ export class DLMM {
     const promiseResults = await Promise.all([
       this.getActiveBin(),
       userPubKey &&
-      this.program.account.position.all([
-        {
-          memcmp: {
-            bytes: bs58.encode(userPubKey.toBuffer()),
-            offset: 8 + 32,
+        this.program.account.position.all([
+          {
+            memcmp: {
+              bytes: bs58.encode(userPubKey.toBuffer()),
+              offset: 8 + 32,
+            },
           },
-        },
-        {
-          memcmp: {
-            bytes: bs58.encode(this.pubkey.toBuffer()),
-            offset: 8,
+          {
+            memcmp: {
+              bytes: bs58.encode(this.pubkey.toBuffer()),
+              offset: 8,
+            },
           },
-        },
-      ]),
+        ]),
       userPubKey &&
-      this.program.account.positionV2.all([
-        {
-          memcmp: {
-            bytes: bs58.encode(userPubKey.toBuffer()),
-            offset: 8 + 32,
+        this.program.account.positionV2.all([
+          {
+            memcmp: {
+              bytes: bs58.encode(userPubKey.toBuffer()),
+              offset: 8 + 32,
+            },
           },
-        },
-        {
-          memcmp: {
-            bytes: bs58.encode(this.pubkey.toBuffer()),
-            offset: 8,
+          {
+            memcmp: {
+              bytes: bs58.encode(this.pubkey.toBuffer()),
+              offset: 8,
+            },
           },
-        },
-      ]),
+        ]),
     ]);
 
     const [activeBin, positions, positionsV2] = promiseResults;
@@ -3151,7 +3151,7 @@ export class DLMM {
     swapForY: boolean,
     allowedSlippage: BN,
     binArrays: BinArrayAccount[],
-    isPartialFill?: boolean,
+    isPartialFill?: boolean
   ): SwapQuote {
     // TODO: Should we use onchain clock ? Volatile fee rate is sensitive to time. Caching clock might causes the quoted fee off ...
     const currentTimestamp = Date.now() / 1000;
@@ -3623,8 +3623,10 @@ export class DLMM {
     const claimAllTxs = (
       await Promise.all(
         positions
-          .filter(({ positionData: { rewardOne, rewardTwo } }) =>
-            !rewardOne.isZero() || !rewardTwo.isZero())
+          .filter(
+            ({ positionData: { rewardOne, rewardTwo } }) =>
+              !rewardOne.isZero() || !rewardTwo.isZero()
+          )
           .map(async (position, idx) => {
             return await this.createClaimBuildMethod({
               owner,
@@ -3742,8 +3744,10 @@ export class DLMM {
     const claimAllTxs = (
       await Promise.all(
         positions
-          .filter(({ positionData: { feeX, feeY } }) =>
-            !feeX.isZero() || !feeY.isZero())
+          .filter(
+            ({ positionData: { feeX, feeY } }) =>
+              !feeX.isZero() || !feeY.isZero()
+          )
           .map(async (position, idx, positions) => {
             return await this.createClaimSwapFeeMethod({
               owner,
@@ -4147,6 +4151,43 @@ export class DLMM {
   }
 
   /**
+   * Initializes bin arrays for the given bin array indexes if it was initialized.
+   *
+   * @param {BN[]} binArrayIndexes - An array of bin array indexes to initialize.
+   * @param {PublicKey} funder - The public key of the funder.
+   * @return {Promise<TransactionInstruction[]>} An array of transaction instructions to initialize the bin arrays.
+   */
+  public async initializeBinArrays(binArrayIndexes: BN[], funder: PublicKey) {
+    const ixs: TransactionInstruction[] = [];
+
+    for (const idx of binArrayIndexes) {
+      const [binArray] = deriveBinArray(
+        this.pubkey,
+        idx,
+        this.program.programId
+      );
+
+      const binArrayAccount =
+        await this.program.provider.connection.getAccountInfo(binArray);
+
+      if (binArrayAccount === null) {
+        ixs.push(
+          await this.program.methods
+            .initializeBinArray(idx)
+            .accounts({
+              binArray,
+              funder,
+              lbPair: this.pubkey,
+            })
+            .instruction()
+        );
+      }
+    }
+
+    return ixs;
+  }
+
+  /**
    *
    * @param
    *    - `lowerBinId`: Lower bin ID of the position. This represent the lowest price of the position
@@ -4283,8 +4324,10 @@ export class DLMM {
     const claimAllSwapFeeTxs = (
       await Promise.all(
         positions
-          .filter(({ positionData: { feeX, feeY } }) =>
-            !feeX.isZero() || !feeY.isZero())
+          .filter(
+            ({ positionData: { feeX, feeY } }) =>
+              !feeX.isZero() || !feeY.isZero()
+          )
           .map(async (position) => {
             return await this.createClaimSwapFeeMethod({
               owner,
@@ -4299,8 +4342,10 @@ export class DLMM {
     const claimAllLMTxs = (
       await Promise.all(
         positions
-          .filter(({ positionData: { rewardOne, rewardTwo } }) =>
-            !rewardOne.isZero() || !rewardTwo.isZero())
+          .filter(
+            ({ positionData: { rewardOne, rewardTwo } }) =>
+              !rewardOne.isZero() || !rewardTwo.isZero()
+          )
           .map(async (position) => {
             return await this.createClaimBuildMethod({
               owner,
@@ -5138,7 +5183,7 @@ export class DLMM {
       if (elapsed < sParameter.decayPeriod) {
         const decayedVolatilityReference = Math.floor(
           (vParameter.volatilityAccumulator * sParameter.reductionFactor) /
-          BASIS_POINT_MAX
+            BASIS_POINT_MAX
         );
         vParameter.volatilityReference = decayedVolatilityReference;
       } else {

--- a/ts-client/src/dlmm/index.ts
+++ b/ts-client/src/dlmm/index.ts
@@ -4151,7 +4151,7 @@ export class DLMM {
   }
 
   /**
-   * Initializes bin arrays for the given bin array indexes if it was initialized.
+   * Initializes bin arrays for the given bin array indexes if it wasn't initialized.
    *
    * @param {BN[]} binArrayIndexes - An array of bin array indexes to initialize.
    * @param {PublicKey} funder - The public key of the funder.

--- a/ts-client/src/examples/initialize_bin_arrays.ts
+++ b/ts-client/src/examples/initialize_bin_arrays.ts
@@ -1,0 +1,75 @@
+import { Connection, Keypair, PublicKey, Transaction } from "@solana/web3.js";
+import { DLMM } from "../dlmm";
+import BN from "bn.js";
+import Decimal from "decimal.js";
+import { getBinArraysRequiredByPositionRange } from "../dlmm/helpers";
+import { simulateTransaction } from "@coral-xyz/anchor/dist/cjs/utils/rpc";
+
+async function initializeBinArrayExample() {
+  const funder = Keypair.fromSecretKey(
+    new Uint8Array(JSON.parse(process.env.WALLET))
+  );
+
+  console.log("Connected wallet", funder.publicKey.toBase58());
+
+  const poolAddress = new PublicKey(
+    "BfxJcifavkCgznhvAtLsBHQpyNwaTMs2cR986qbH4fPh"
+  );
+
+  let rpc = "https://api.mainnet-beta.solana.com";
+  const connection = new Connection(rpc, "finalized");
+  const dlmmPool = await DLMM.create(connection, poolAddress, {
+    cluster: "mainnet-beta",
+  });
+
+  const fromUIPrice = 1.0;
+  const toUIPrice = 4.0;
+
+  const toLamportMultiplier = new Decimal(
+    10 ** (dlmmPool.tokenY.decimal - dlmmPool.tokenX.decimal)
+  );
+
+  const minPricePerLamport = new Decimal(fromUIPrice).mul(toLamportMultiplier);
+  const maxPricePerLamport = new Decimal(toUIPrice).mul(toLamportMultiplier);
+
+  const minBinId = new BN(
+    DLMM.getBinIdFromPrice(minPricePerLamport, dlmmPool.lbPair.binStep, false)
+  );
+
+  const maxBinId = new BN(
+    DLMM.getBinIdFromPrice(maxPricePerLamport, dlmmPool.lbPair.binStep, false)
+  );
+
+  const binArraysRequired = getBinArraysRequiredByPositionRange(
+    poolAddress,
+    minBinId,
+    maxBinId,
+    dlmmPool.program.programId
+  );
+
+  console.log(binArraysRequired);
+
+  const initializeBinArrayIxs = await dlmmPool.initializeBinArrays(
+    binArraysRequired.map((b) => b.index),
+    funder.publicKey
+  );
+
+  const { blockhash, lastValidBlockHeight } =
+    await connection.getLatestBlockhash();
+
+  const transaction = new Transaction({
+    blockhash,
+    lastValidBlockHeight,
+    feePayer: funder.publicKey,
+  }).add(...initializeBinArrayIxs);
+
+  transaction.sign(funder);
+
+  const simulationResult = await simulateTransaction(connection, transaction, [
+    funder,
+  ]);
+
+  console.log(simulationResult);
+}
+
+initializeBinArrayExample();

--- a/ts-client/src/examples/swap_quote.ts
+++ b/ts-client/src/examples/swap_quote.ts
@@ -1,11 +1,13 @@
-import {
-  Connection,
-  PublicKey,
-} from "@solana/web3.js";
+import { Connection, PublicKey } from "@solana/web3.js";
 import { DLMM } from "../dlmm";
 import BN from "bn.js";
 
-async function swapQuote(poolAddress: PublicKey, swapAmount: BN, swapYtoX: boolean, isPartialFill: boolean) {
+async function swapQuote(
+  poolAddress: PublicKey,
+  swapAmount: BN,
+  swapYtoX: boolean,
+  isPartialFill: boolean
+) {
   let rpc = "https://api.mainnet-beta.solana.com";
   const connection = new Connection(rpc, "finalized");
   const dlmmPool = await DLMM.create(connection, poolAddress, {
@@ -13,16 +15,28 @@ async function swapQuote(poolAddress: PublicKey, swapAmount: BN, swapYtoX: boole
   });
 
   const binArrays = await dlmmPool.getBinArrayForSwap(swapYtoX);
-  const swapQuote = await dlmmPool.swapQuote(swapAmount, swapYtoX, new BN(10), binArrays, isPartialFill);
+  const swapQuote = await dlmmPool.swapQuote(
+    swapAmount,
+    swapYtoX,
+    new BN(10),
+    binArrays,
+    isPartialFill
+  );
   console.log("🚀 ~ swapQuote:", swapQuote);
-  console.log("consumedInAmount: %s, outAmount: %s", swapQuote.consumedInAmount.toString(), swapQuote.outAmount.toString());
+  console.log(
+    "consumedInAmount: %s, outAmount: %s",
+    swapQuote.consumedInAmount.toString(),
+    swapQuote.outAmount.toString()
+  );
 }
 
 async function main() {
-  await swapQuote(new PublicKey(
-    "8kCbYxnF8ggdJACxz4NLYtVhEEz6EBvN5NQcKAazpkEY"
-  ), new BN(1_000_000_000), true, true);
+  await swapQuote(
+    new PublicKey("8kCbYxnF8ggdJACxz4NLYtVhEEz6EBvN5NQcKAazpkEY"),
+    new BN(1_000_000_000),
+    true,
+    true
+  );
 }
 
-
-main()
+main();


### PR DESCRIPTION
### Added

- `getBinArraysRequiredByPositionRange`. Retrieves the bin arrays required to initialize multiple positions in continuous range.
- `initializeBinArrays`. Initializes bin arrays for the given bin array indexes if it wasn't initialized.

Check `dlmm-sdk/ts-client/src/examples/initialize_bin_arrays.ts` for example reference.