### PR TITLE
fix: swap quote on edge case

### DIFF
--- a/ts-client/package.json
+++ b/ts-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meteora-ag/dlmm",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/ts-client/src/dlmm/error.ts
+++ b/ts-client/src/dlmm/error.ts
@@ -4,6 +4,7 @@ import { LBCLMM_PROGRAM_IDS } from "./constants";
 
 type Codes = (typeof IDL.errors)[number]["code"];
 
+// ProgramError error parser
 export class DLMMError extends Error {
   public errorCode: number;
   public errorName: string;
@@ -41,5 +42,19 @@ export class DLMMError extends Error {
     this.errorCode = _errorCode;
     this.errorName = _errorName;
     this.errorMessage = _errorMessage;
+  }
+}
+
+// SDK error
+type ErrorName = "SWAP_QUOTE_INSUFFICIENT_LIQUIDITY";
+
+export class DlmmSdkError extends Error {
+  name: ErrorName;
+  message: string;
+
+  constructor(name: ErrorName, message: string) {
+    super();
+    this.name = name;
+    this.message = message;
   }
 }

--- a/ts-client/src/dlmm/helpers/binArray.ts
+++ b/ts-client/src/dlmm/helpers/binArray.ts
@@ -318,8 +318,8 @@ export function findNextBinArrayWithLiquidity(
     ba.account.index.eq(nearestBinArrayIndexWithLiquidity)
   );
   if (!binArrayAccount) {
-    // Critical bug
-    throw new Error("Bin array not found based on indexing");
+    // Cached bin array couldn't cover more bins, partial quoted.
+    return null;
   }
 
   return binArrayAccount;

--- a/ts-client/src/dlmm/index.ts
+++ b/ts-client/src/dlmm/index.ts
@@ -3366,7 +3366,26 @@ export class DLMM {
       }
     }
 
-    if (!startBin) throw new Error("Invalid start bin");
+    if (!startBin) {
+      if (isPartialFill) {
+        // Nothing consumed due to no liquidity
+        return {
+          consumedInAmount: new BN(0),
+          outAmount: new BN(0),
+          fee: new BN(0),
+          protocolFee: new BN(0),
+          minOutAmount: new BN(0),
+          priceImpact: new Decimal(0),
+          binArraysPubkey: [],
+          endPrice: getPriceOfBinByBinId(
+            activeId.toNumber(),
+            this.lbPair.binStep
+          ),
+        };
+      } else {
+        throw new Error("Insufficient liquidity");
+      }
+    }
 
     inAmount = inAmount.sub(inAmountLeft);
 

--- a/ts-client/src/dlmm/index.ts
+++ b/ts-client/src/dlmm/index.ts
@@ -128,6 +128,7 @@ import {
   mulShr,
   shlDiv,
 } from "./helpers/math";
+import { DlmmSdkError } from "./error";
 
 type Opt = {
   cluster?: Cluster | "localhost";
@@ -3142,6 +3143,8 @@ export class DLMM {
    *    - `protocolFee`: Protocol fee amount
    *    - `maxInAmount`: Maximum amount of lamport to swap in
    *    - `binArraysPubkey`: Array of bin arrays involved in the swap
+   * @throws {DlmmSdkError}
+   *
    */
   public swapQuoteExactOut(
     outAmount: BN,
@@ -3182,7 +3185,10 @@ export class DLMM {
       );
 
       if (binArrayAccountToSwap == null) {
-        throw new Error("Insufficient liquidity");
+        throw new DlmmSdkError(
+          "SWAP_QUOTE_INSUFFICIENT_LIQUIDITY",
+          "Insufficient liquidity in binArrays"
+        );
       }
 
       binArraysForSwap.set(binArrayAccountToSwap.publicKey, true);
@@ -3273,6 +3279,7 @@ export class DLMM {
    *    - `minOutAmount`: Minimum amount of lamport to swap out
    *    - `priceImpact`: Price impact of the swap
    *    - `binArraysPubkey`: Array of bin arrays involved in the swap
+   * @throws {DlmmSdkError}
    */
   public swapQuote(
     inAmount: BN,
@@ -3317,7 +3324,10 @@ export class DLMM {
         if (isPartialFill) {
           break;
         } else {
-          throw new Error("Insufficient liquidity");
+          throw new DlmmSdkError(
+            "SWAP_QUOTE_INSUFFICIENT_LIQUIDITY",
+            "Insufficient liquidity in binArrays for swapQuote"
+          );
         }
       }
 
@@ -3367,24 +3377,11 @@ export class DLMM {
     }
 
     if (!startBin) {
-      if (isPartialFill) {
-        // Nothing consumed due to no liquidity
-        return {
-          consumedInAmount: new BN(0),
-          outAmount: new BN(0),
-          fee: new BN(0),
-          protocolFee: new BN(0),
-          minOutAmount: new BN(0),
-          priceImpact: new Decimal(0),
-          binArraysPubkey: [],
-          endPrice: getPriceOfBinByBinId(
-            activeId.toNumber(),
-            this.lbPair.binStep
-          ),
-        };
-      } else {
-        throw new Error("Insufficient liquidity");
-      }
+      // The pool insufficient liquidity
+      throw new DlmmSdkError(
+        "SWAP_QUOTE_INSUFFICIENT_LIQUIDITY",
+        "Insufficient liquidity"
+      );
     }
 
     inAmount = inAmount.sub(inAmountLeft);


### PR DESCRIPTION
In the normal scenario, integrator will only cache N bin arrays to the right and left of the active ID based on the bin step compute unit usage, and the volatility of the pair, instead of caching all bin arrays.

Case 1.
The quote in amount more than liquidity of client side cached bin arrays, but all bin arrays of the pool on chain are able to fulfill the in amount.
The swap quote will throw the below error even with `isPartialFill` true. The reason is that the bitmap still able to find the next bin array for swap, but client side doesn't cache enough bin array.
https://github.com/MeteoraAg/dlmm-sdk/blob/20fdbc0e46a806da2b16bcab6d63cd321ba35136/ts-client/src/dlmm/helpers/binArray.ts#L322
One may try to cache more bin arrays to avoid the error, but if the swap quote consumes more than 3 bin arrays, it's quite high likely that the actual swap will out of compute unit which will still fail in the end.

Case 2.
The pool consists of one type of token. In this case, token X. When attempt to quote for Y token, the swap quote will throw the below error.
https://github.com/MeteoraAg/dlmm-sdk/blob/20fdbc0e46a806da2b16bcab6d63cd321ba35136/ts-client/src/dlmm/index.ts#L3369
The reason is that there's still available bin array with liquidity for quote (which is the active bin array). However, the active bin is the last bin with liquidity and contain no token Y. Therefore, it couldn't locate any bin for quoting and throw `Invalid start bin`. It shall throw a more meaningful error message.