### PR TITLE
Support creating empty positions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+## @meteora-ag/dlmm [1.1.51] - PR #108
+
+### Added
+
+- new method `createEmptyPosition` allows to create an empty position with the corresponding bin arrays.
+
 ## @meteora-ag/dlmm [1.1.5] - PR #107
 
 ### Fixed

--- a/ts-client/package.json
+++ b/ts-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meteora-ag/dlmm",
-  "version": "1.1.5",
+  "version": "1.1.51",
   "description": "",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",


### PR DESCRIPTION
This pull request introduces a new method `createEmptyPosition` that allows to create an empty (no initial liquidity) position with the corresponding bin arrays if needed. It's useful for automation scenarios for creating new empty positions in advance and supplying liquidity lately when the prices moves closer to them.