### PR TITLE
Fix array indices calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
-## @meteora-ag/dlmm [1.2.3] - PR #111
+## @meteora-ag/dlmm [1.2.3] - PR #112
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+## @meteora-ag/dlmm [1.2.3] - PR #111
+
+### Fixed
+
+- Fixed `addLiquidityByStrategy` incorrect array bin indices calculation
+
 ## @meteora-ag/dlmm [1.2.2] - PR #110
 
 ### Fixed

--- a/ts-client/package.json
+++ b/ts-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meteora-ag/dlmm",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/ts-client/src/dlmm/index.ts
+++ b/ts-client/src/dlmm/index.ts
@@ -2410,21 +2410,32 @@ export class DLMM {
       ? deriveBinArrayBitmapExtension(this.pubkey, this.program.programId)[0]
       : null;
 
-    const activeId = this.lbPair.activeId;
-
     const strategyParameters: LiquidityParameterByStrategy["strategyParameters"] =
       toStrategyParameters(strategy) as ProgramStrategyParameter;
 
-    const lowerBinArrayIndex = binIdToBinArrayIndex(new BN(minBinId));
+    const positionAccount = await this.program.account.positionV2.fetch(
+      positionPubKey
+    );
+
+    const positionLowerBinArrayIndex = binIdToBinArrayIndex(new BN(positionAccount.lowerBinId));
+    let lowerBinArrayIndex = binIdToBinArrayIndex(new BN(minBinId));
+    let upperBinArrayIndex = binIdToBinArrayIndex(new BN(maxBinId));
+    if (lowerBinArrayIndex.eq(positionLowerBinArrayIndex)) {
+      upperBinArrayIndex= BN.max(
+        lowerBinArrayIndex.add(new BN(1)),
+        upperBinArrayIndex
+      );
+    } else {
+      lowerBinArrayIndex =  BN.min(
+        upperBinArrayIndex.sub(new BN(1)),
+        lowerBinArrayIndex
+      );
+    }
+
     const [binArrayLower] = deriveBinArray(
       this.pubkey,
       lowerBinArrayIndex,
       this.program.programId
-    );
-
-    const upperBinArrayIndex = BN.max(
-      lowerBinArrayIndex.add(new BN(1)),
-      binIdToBinArrayIndex(new BN(maxBinId))
     );
     const [binArrayUpper] = deriveBinArray(
       this.pubkey,

--- a/ts-client/src/dlmm/index.ts
+++ b/ts-client/src/dlmm/index.ts
@@ -2421,12 +2421,12 @@ export class DLMM {
     let lowerBinArrayIndex = binIdToBinArrayIndex(new BN(minBinId));
     let upperBinArrayIndex = binIdToBinArrayIndex(new BN(maxBinId));
     if (lowerBinArrayIndex.eq(positionLowerBinArrayIndex)) {
-      upperBinArrayIndex= BN.max(
+      upperBinArrayIndex = BN.max(
         lowerBinArrayIndex.add(new BN(1)),
         upperBinArrayIndex
       );
     } else {
-      lowerBinArrayIndex =  BN.min(
+      lowerBinArrayIndex = BN.min(
         upperBinArrayIndex.sub(new BN(1)),
         lowerBinArrayIndex
       );

--- a/ts-client/src/dlmm/index.ts
+++ b/ts-client/src/dlmm/index.ts
@@ -2413,24 +2413,10 @@ export class DLMM {
     const strategyParameters: LiquidityParameterByStrategy["strategyParameters"] =
       toStrategyParameters(strategy) as ProgramStrategyParameter;
 
-    const positionAccount = await this.program.account.positionV2.fetch(
-      positionPubKey
-    );
+    const positionAccount = await this.program.account.positionV2.fetch(positionPubKey);
 
-    const positionLowerBinArrayIndex = binIdToBinArrayIndex(new BN(positionAccount.lowerBinId));
-    let lowerBinArrayIndex = binIdToBinArrayIndex(new BN(minBinId));
-    let upperBinArrayIndex = binIdToBinArrayIndex(new BN(maxBinId));
-    if (lowerBinArrayIndex.eq(positionLowerBinArrayIndex)) {
-      upperBinArrayIndex = BN.max(
-        lowerBinArrayIndex.add(new BN(1)),
-        upperBinArrayIndex
-      );
-    } else {
-      lowerBinArrayIndex = BN.min(
-        upperBinArrayIndex.sub(new BN(1)),
-        lowerBinArrayIndex
-      );
-    }
+    const lowerBinArrayIndex = binIdToBinArrayIndex(new BN(positionAccount.lowerBinId));
+    const upperBinArrayIndex = lowerBinArrayIndex.add(new BN(1));
 
     const [binArrayLower] = deriveBinArray(
       this.pubkey,


### PR DESCRIPTION
This patch fixes the bin array indices calculation in the `addLiquidityByStrategy` method. Prev the indices could be outside the range of the actual min /max bin array indices a position can have.