### PR TITLE
Fix typo in python-client fun name

### DIFF
--- a/python-client/dlmm/dlmm/dlmm.py
+++ b/python-client/dlmm/dlmm/dlmm.py
@@ -608,7 +608,7 @@ class DLMM:
         except requests.exceptions.ConnectionError as e:
             raise HTTPError(f"Error connecting to DLMM: {e}")
     
-    def claim_all_LM_reards(self, owner: Pubkey, positions: List[Position]) -> List[Transaction]:
+    def claim_all_LM_rewards(self, owner: Pubkey, positions: List[Position]) -> List[Transaction]:
         '''
         The function is used to claim all liquidity mining rewards for a given owner and their positions.
 


### PR DESCRIPTION
Not sure if you are accepting typo related PR. Anyway, I found a typo in one of the python-client function names, and thought it should be fixed