### PR TITLE
fix: accept 0 as valid slippage value by handling falsy check

### DIFF
--- a/ts-client/src/dlmm/index.ts
+++ b/ts-client/src/dlmm/index.ts
@@ -1788,7 +1788,7 @@ export class DLMM {
   }: TInitializePositionAndAddLiquidityParamsByStrategy) {
     const { maxBinId, minBinId } = strategy;
 
-    const maxActiveBinSlippage = slippage
+    const maxActiveBinSlippage = slippage !== null && slippage !== undefined
       ? Math.ceil(slippage / (this.lbPair.binStep / 100))
       : MAX_ACTIVE_BIN_SLIPPAGE;
 
@@ -1973,7 +1973,7 @@ export class DLMM {
     const { lowerBinId, upperBinId, binIds } =
       this.processXYAmountDistribution(xYAmountDistribution);
 
-    const maxActiveBinSlippage = slippage
+    const maxActiveBinSlippage = slippage !== null && slippage !== undefined
       ? Math.ceil(slippage / (this.lbPair.binStep / 100))
       : MAX_ACTIVE_BIN_SLIPPAGE;
 
@@ -2249,7 +2249,7 @@ export class DLMM {
   }: TInitializePositionAndAddLiquidityParamsByStrategy): Promise<Transaction> {
     const { maxBinId, minBinId } = strategy;
 
-    const maxActiveBinSlippage = slippage
+    const maxActiveBinSlippage = slippage !== null && slippage !== undefined
       ? Math.ceil(slippage / (this.lbPair.binStep / 100))
       : MAX_ACTIVE_BIN_SLIPPAGE;
 
@@ -2422,7 +2422,7 @@ export class DLMM {
   }: TInitializePositionAndAddLiquidityParams): Promise<
     Transaction | Transaction[]
   > {
-    const maxActiveBinSlippage = slippage
+    const maxActiveBinSlippage = slippage !== null && slippage !== undefined
       ? Math.ceil(slippage / (this.lbPair.binStep / 100))
       : MAX_ACTIVE_BIN_SLIPPAGE;
 


### PR DESCRIPTION
- Resolved an issue where slippage value of 0 was incorrectly treated as falsy, causing it to default to MAX_ACTIVE_BIN_SLIPPAGE.
- Updated the logic to explicitly check for null or undefined, allowing 0 to be correctly processed.