### PR TITLE
fix: Add param maxExtraBinArrays for swapQuote

### DIFF
--- a/.github/workflows/ci-pr-main-sdk.yml
+++ b/.github/workflows/ci-pr-main-sdk.yml
@@ -31,6 +31,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: sdk_changed_files
     if: needs.sdk_changed_files.outputs.sdk == 'true'
+    env:
+      RPC: ${{ secrets.RPC }}
     steps:
       - uses: actions/checkout@v2
       - uses: ./.github/actions/setup-solana

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add param `maxExtraBinArrays` in `swapQuote` function.
+- Add param `maxExtraBinArrays` to `swapQuote` and `swapQuoteExactOut` functions.
 
 ## @meteora-ag/dlmm [1.3.13] - PR #166
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add param `returnExtraBinArrays` in `swapQuote` function.
+- Add param `maxExtraBinArrays` in `swapQuote` function.
 
 ## @meteora-ag/dlmm [1.3.13] - PR #166
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+## @meteora-ag/dlmm [1.3.14] - PR #167
+
+### Added
+
+- Add param `returnExtraBinArrays` in `swapQuote` function.
+
 ## @meteora-ag/dlmm [1.3.13] - PR #166
 
 ### Added

--- a/ts-client/package.json
+++ b/ts-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meteora-ag/dlmm",
-  "version": "1.3.13",
+  "version": "1.3.14",
   "description": "",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/ts-client/src/dlmm/constants/index.ts
+++ b/ts-client/src/dlmm/constants/index.ts
@@ -61,3 +61,5 @@ export const MAX_ACTIVE_BIN_SLIPPAGE = 3;
 export const ILM_BASE = new PublicKey(
   "MFGQxwAmB91SwuYX36okv2Qmdc9aMuHTwWGUrp4AtB1"
 );
+
+export const MAX_EXTRA_BIN_ARRAYS = 5;

--- a/ts-client/src/dlmm/constants/index.ts
+++ b/ts-client/src/dlmm/constants/index.ts
@@ -62,4 +62,4 @@ export const ILM_BASE = new PublicKey(
   "MFGQxwAmB91SwuYX36okv2Qmdc9aMuHTwWGUrp4AtB1"
 );
 
-export const MAX_EXTRA_BIN_ARRAYS = 5;
+export const MAX_EXTRA_BIN_ARRAYS = 3;

--- a/ts-client/src/dlmm/error.ts
+++ b/ts-client/src/dlmm/error.ts
@@ -46,7 +46,7 @@ export class DLMMError extends Error {
 }
 
 // SDK error
-type ErrorName = "SWAP_QUOTE_INSUFFICIENT_LIQUIDITY";
+type ErrorName = "SWAP_QUOTE_INSUFFICIENT_LIQUIDITY" | "INVALID_MAX_EXTRA_BIN_ARRAYS";
 
 export class DlmmSdkError extends Error {
   name: ErrorName;

--- a/ts-client/src/dlmm/index.ts
+++ b/ts-client/src/dlmm/index.ts
@@ -3394,6 +3394,9 @@ export class DLMM {
     const extraBinArrays = binArrays.map(item => item.publicKey).filter(binArrayPubkey => !binArraysForSwap.has(binArrayPubkey));
     const binArraysForSwapKeys = Array.from(binArraysForSwap.keys());
     const extraBinArrayIndexEnd = maxExtraBinArrays | 0;
+    if (extraBinArrayIndexEnd < 0) {
+      throw new DlmmSdkError("INVALID_MAX_EXTRA_BIN_ARRAYS", "maxExtraBinArrays must be greater than or equal 0");
+    }
     const binArraysPubkey = [...binArraysForSwapKeys, ...extraBinArrays.slice(0, extraBinArrayIndexEnd)];
 
     return {

--- a/ts-client/src/dlmm/index.ts
+++ b/ts-client/src/dlmm/index.ts
@@ -3298,6 +3298,7 @@ export class DLMM {
     }
 
     while (!inAmountLeft.isZero()) {
+      console.log(activeId.toNumber());
       let binArrayAccountToSwap = findNextBinArrayWithLiquidity(
         swapForY,
         activeId,
@@ -3307,11 +3308,7 @@ export class DLMM {
       );
 
       if (binArrayAccountToSwap == null) {
-        if (extraBinArrayIndex < maxExtraBinArrays) {
-          // incase the liquidity is insufficient and user want to get extra bin array
-          extraBinArrayIndex++;
-          continue;
-        } else if (isPartialFill) {
+        if (isPartialFill) {
           break;
         } else {
           throw new DlmmSdkError(

--- a/ts-client/src/dlmm/index.ts
+++ b/ts-client/src/dlmm/index.ts
@@ -3307,12 +3307,12 @@ export class DLMM {
       );
 
       if (binArrayAccountToSwap == null) {
-        if (isPartialFill) {
-          break;
-        } else if (extraBinArrayIndex < maxExtraBinArrays) {
+        if (extraBinArrayIndex < maxExtraBinArrays) {
           // incase the liquidity is insufficient and user want to get extra bin array
           extraBinArrayIndex++;
           continue;
+        } else if (isPartialFill) {
+          break;
         } else {
           throw new DlmmSdkError(
             "SWAP_QUOTE_INSUFFICIENT_LIQUIDITY",

--- a/ts-client/src/dlmm/index.ts
+++ b/ts-client/src/dlmm/index.ts
@@ -3248,7 +3248,7 @@ export class DLMM {
    *    - `allowedSlippage`: Allowed slippage for the swap. Expressed in BPS. To convert from slippage percentage to BPS unit: SLIPPAGE_PERCENTAGE * 100
    *    - `binArrays`: binArrays for swapQuote.
    *    - `isPartialFill`: Flag to check whether the the swapQuote is partial fill, default = false.
-   *    - `returnExtraBinArrays`: Flag to indicate whether the function should return extra bin arrays along with the bin arrays used for swap
+   *    - `maxExtraBinArrays`: Maximum number of extra binArrays to return
    * @returns {SwapQuote}
    *    - `consumedInAmount`: Amount of lamport to swap in
    *    - `outAmount`: Amount of lamport to swap out
@@ -3265,7 +3265,7 @@ export class DLMM {
     allowedSlippage: BN,
     binArrays: BinArrayAccount[],
     isPartialFill?: boolean,
-    returnExtraBinArrays?: boolean
+    maxExtraBinArrays?: number
   ): SwapQuote {
     // TODO: Should we use onchain clock ? Volatile fee rate is sensitive to time. Caching clock might causes the quoted fee off ...
     const currentTimestamp = Date.now() / 1000;
@@ -3393,7 +3393,8 @@ export class DLMM {
     // Extra binArrays that doesn't exist in the binArraysForSwap
     const extraBinArrays = binArrays.map(item => item.publicKey).filter(binArrayPubkey => !binArraysForSwap.has(binArrayPubkey));
     const binArraysForSwapKeys = Array.from(binArraysForSwap.keys());
-    const binArraysPubkey = returnExtraBinArrays ? [...binArraysForSwapKeys, ...extraBinArrays] : [...binArraysForSwapKeys];
+    const extraBinArrayIndexEnd = maxExtraBinArrays | 0;
+    const binArraysPubkey = [...binArraysForSwapKeys, ...extraBinArrays.slice(0, extraBinArrayIndexEnd)];
 
     return {
       consumedInAmount: inAmount,

--- a/ts-client/src/dlmm/index.ts
+++ b/ts-client/src/dlmm/index.ts
@@ -140,6 +140,7 @@ import {
   vParameters,
 } from "./types";
 import { DEFAULT_ADD_LIQUIDITY_CU } from "./helpers/computeUnit";
+import { max, min } from "bn.js";
 
 type Opt = {
   cluster?: Cluster | "localhost";
@@ -3421,10 +3422,12 @@ export class DLMM {
           }
         } else {
           extraBinArrays.push(binArrayAccountToSwap.publicKey);
+          const [lowerBinId, upperBinId] = getBinArrayLowerUpperBinId(binArrayAccountToSwap.account.index);
+
           if (swapForY) {
-            activeId = activeId.sub(new BN(binArrayAccountToSwap.account.bins.length));
+            activeId = lowerBinId.sub(new BN(1));
           } else {
-            activeId = activeId.add(new BN(binArrayAccountToSwap.account.bins.length));
+            activeId = upperBinId.add(new BN(1));
           }
         }
       }

--- a/ts-client/src/dlmm/index.ts
+++ b/ts-client/src/dlmm/index.ts
@@ -3248,6 +3248,7 @@ export class DLMM {
    *    - `allowedSlippage`: Allowed slippage for the swap. Expressed in BPS. To convert from slippage percentage to BPS unit: SLIPPAGE_PERCENTAGE * 100
    *    - `binArrays`: binArrays for swapQuote.
    *    - `isPartialFill`: Flag to check whether the the swapQuote is partial fill, default = false.
+   *    - `returnExtraBinArrays`: Flag to indicate whether the function should return extra bin arrays along with the bin arrays used for swap
    * @returns {SwapQuote}
    *    - `consumedInAmount`: Amount of lamport to swap in
    *    - `outAmount`: Amount of lamport to swap out
@@ -3263,7 +3264,8 @@ export class DLMM {
     swapForY: boolean,
     allowedSlippage: BN,
     binArrays: BinArrayAccount[],
-    isPartialFill?: boolean
+    isPartialFill?: boolean,
+    returnExtraBinArrays?: boolean
   ): SwapQuote {
     // TODO: Should we use onchain clock ? Volatile fee rate is sensitive to time. Caching clock might causes the quoted fee off ...
     const currentTimestamp = Date.now() / 1000;
@@ -3388,6 +3390,11 @@ export class DLMM {
       this.lbPair.binStep
     );
 
+    // Extra binArrays that doesn't exist in the binArraysForSwap
+    const extraBinArrays = binArrays.map(item => item.publicKey).filter(binArrayPubkey => !binArraysForSwap.has(binArrayPubkey));
+    const binArraysForSwapKeys = Array.from(binArraysForSwap.keys());
+    const binArraysPubkey = returnExtraBinArrays ? [...binArraysForSwapKeys, ...extraBinArrays] : [...binArraysForSwapKeys];
+
     return {
       consumedInAmount: inAmount,
       outAmount: actualOutAmount,
@@ -3395,7 +3402,7 @@ export class DLMM {
       protocolFee: protocolFeeAmount,
       minOutAmount,
       priceImpact,
-      binArraysPubkey: [...binArraysForSwap.keys()],
+      binArraysPubkey,
       endPrice,
     };
   }

--- a/ts-client/src/dlmm/index.ts
+++ b/ts-client/src/dlmm/index.ts
@@ -3420,7 +3420,6 @@ export class DLMM {
         } else {
           activeId = activeId.add(new BN(1));
         }
-        continue;
       }
     }
 

--- a/ts-client/src/examples/swap_quote.ts
+++ b/ts-client/src/examples/swap_quote.ts
@@ -17,6 +17,9 @@ async function swapQuote(
 
   const binArrays = await dlmmPool.getBinArrayForSwap(swapYtoX);
   console.log(`binArrays length ${binArrays.length}`);
+  binArrays.forEach(binArray => {
+    console.log("binArray pubkey ", binArray.publicKey);
+  })
 
   const swapQuote = dlmmPool.swapQuote(
     swapAmount,
@@ -36,11 +39,11 @@ async function swapQuote(
 
 async function main() {
   await swapQuote(
-    new PublicKey("HTvjzsfX3yU6BUodCjZ5vZkUrAxMDTrBs3CJaq43ashR"),
-    new BN(20_000 * 10 ** 6),
+    new PublicKey("5BKxfWMbmYBAEWvyPZS9esPducUba9GqyMjtLCfbaqyF"),
+    new BN(5_000 * 10 ** 6),
     true,
     false,
-    1
+    2
   );
 }
 

--- a/ts-client/src/examples/swap_quote.ts
+++ b/ts-client/src/examples/swap_quote.ts
@@ -7,7 +7,7 @@ async function swapQuote(
   swapAmount: BN,
   swapYtoX: boolean,
   isPartialFill: boolean,
-  maxExtraBinArrays?: number
+  maxExtraBinArrays: number = 0
 ) {
   let rpc = "https://api.mainnet-beta.solana.com";
   const connection = new Connection(rpc, "finalized");
@@ -16,7 +16,7 @@ async function swapQuote(
   });
 
   const binArrays = await dlmmPool.getBinArrayForSwap(swapYtoX);
-  const swapQuote = await dlmmPool.swapQuote(
+  const swapQuote = dlmmPool.swapQuote(
     swapAmount,
     swapYtoX,
     new BN(10),
@@ -34,11 +34,10 @@ async function swapQuote(
 
 async function main() {
   await swapQuote(
-    new PublicKey("5BKxfWMbmYBAEWvyPZS9esPducUba9GqyMjtLCfbaqyF"),
-    new BN(1_000_000_000_000),
+    new PublicKey("8gJ7UWboMeQ6z6AQwFP3cAZwSYG8udVS2UesyCbH79r7"),
+    new BN(1_000_000 * 10 ** 6),
     true,
     true,
-    0
   );
 }
 

--- a/ts-client/src/examples/swap_quote.ts
+++ b/ts-client/src/examples/swap_quote.ts
@@ -6,7 +6,8 @@ async function swapQuote(
   poolAddress: PublicKey,
   swapAmount: BN,
   swapYtoX: boolean,
-  isPartialFill: boolean
+  isPartialFill: boolean,
+  returnExtraBinArrays?: boolean
 ) {
   let rpc = "https://api.mainnet-beta.solana.com";
   const connection = new Connection(rpc, "finalized");
@@ -20,7 +21,8 @@ async function swapQuote(
     swapYtoX,
     new BN(10),
     binArrays,
-    isPartialFill
+    isPartialFill,
+    returnExtraBinArrays
   );
   console.log("🚀 ~ swapQuote:", swapQuote);
   console.log(
@@ -32,8 +34,9 @@ async function swapQuote(
 
 async function main() {
   await swapQuote(
-    new PublicKey("8kCbYxnF8ggdJACxz4NLYtVhEEz6EBvN5NQcKAazpkEY"),
-    new BN(1_000_000_000),
+    new PublicKey("5BKxfWMbmYBAEWvyPZS9esPducUba9GqyMjtLCfbaqyF"),
+    new BN(1_000_000),
+    true,
     true,
     true
   );

--- a/ts-client/src/examples/swap_quote.ts
+++ b/ts-client/src/examples/swap_quote.ts
@@ -16,6 +16,8 @@ async function swapQuote(
   });
 
   const binArrays = await dlmmPool.getBinArrayForSwap(swapYtoX);
+  console.log(`binArrays length ${binArrays.length}`);
+
   const swapQuote = dlmmPool.swapQuote(
     swapAmount,
     swapYtoX,
@@ -34,10 +36,11 @@ async function swapQuote(
 
 async function main() {
   await swapQuote(
-    new PublicKey("8gJ7UWboMeQ6z6AQwFP3cAZwSYG8udVS2UesyCbH79r7"),
-    new BN(1_000_000 * 10 ** 6),
+    new PublicKey("HTvjzsfX3yU6BUodCjZ5vZkUrAxMDTrBs3CJaq43ashR"),
+    new BN(20_000 * 10 ** 6),
     true,
-    true,
+    false,
+    1
   );
 }
 

--- a/ts-client/src/examples/swap_quote.ts
+++ b/ts-client/src/examples/swap_quote.ts
@@ -7,7 +7,7 @@ async function swapQuote(
   swapAmount: BN,
   swapYtoX: boolean,
   isPartialFill: boolean,
-  returnExtraBinArrays?: boolean
+  maxExtraBinArrays?: number
 ) {
   let rpc = "https://api.mainnet-beta.solana.com";
   const connection = new Connection(rpc, "finalized");
@@ -22,7 +22,7 @@ async function swapQuote(
     new BN(10),
     binArrays,
     isPartialFill,
-    returnExtraBinArrays
+    maxExtraBinArrays
   );
   console.log("🚀 ~ swapQuote:", swapQuote);
   console.log(
@@ -35,10 +35,10 @@ async function swapQuote(
 async function main() {
   await swapQuote(
     new PublicKey("5BKxfWMbmYBAEWvyPZS9esPducUba9GqyMjtLCfbaqyF"),
-    new BN(1_000_000),
+    new BN(1_000_000_000_000),
     true,
     true,
-    true
+    0
   );
 }
 

--- a/ts-client/src/examples/swap_quote.ts
+++ b/ts-client/src/examples/swap_quote.ts
@@ -16,10 +16,6 @@ async function swapQuote(
   });
 
   const binArrays = await dlmmPool.getBinArrayForSwap(swapYtoX);
-  console.log(`binArrays length ${binArrays.length}`);
-  binArrays.forEach(binArray => {
-    console.log("binArray pubkey ", binArray.publicKey);
-  })
 
   const swapQuote = dlmmPool.swapQuote(
     swapAmount,

--- a/ts-client/src/examples/swap_quote.ts
+++ b/ts-client/src/examples/swap_quote.ts
@@ -39,7 +39,7 @@ async function main() {
     new BN(5_000 * 10 ** 6),
     true,
     false,
-    2
+    3
   );
 }
 

--- a/ts-client/src/test/sdk.test.ts
+++ b/ts-client/src/test/sdk.test.ts
@@ -2437,9 +2437,29 @@ describe("SDK Test with Mainnet RPC", () => {
     expect(binArrays.length).toBeGreaterThan(1);
     let quote = lbPair.swapQuote(inAmount, swapForY, allowedSlippage, binArrays, isPartialFill, 0);
     expect(quote.binArraysPubkey.length).toEqual(1);
+    const binArrayToSwapPubkey = quote.binArraysPubkey[0];
+    const binArrayToSwap = await lbPair.program.account.binArray.fetch(binArrayToSwapPubkey);
 
     quote = lbPair.swapQuote(inAmount, swapForY, allowedSlippage, binArrays, isPartialFill, 3);
     expect(quote.binArraysPubkey.length).toEqual(4);
+
+    // expect binArrays are in correct order
+    expect(quote.binArraysPubkey[0]).toEqual(binArrayToSwapPubkey);
+
+    let lastBinArrayIdx = binArrayToSwap.index;
+    for (let i = 1; i < binArrays.length; i++) {
+      let assertBinArrayPubkey = quote.binArraysPubkey[i];
+
+      const assertBinArray = await lbPair.program.account.binArray.fetch(assertBinArrayPubkey);
+      console.log(assertBinArray.index);
+      if (swapForY) {
+        expect(assertBinArray.index).toEqual(lastBinArrayIdx.sub(new BN(1)));
+      } else {
+        expect(assertBinArray.index).toEqual(lastBinArrayIdx.add(new BN(1)));
+      }
+
+      lastBinArrayIdx = assertBinArray.index;
+    }
   });
 
   it("quote Y -> X with maxExtraBinArrays", async () => {
@@ -2455,7 +2475,28 @@ describe("SDK Test with Mainnet RPC", () => {
     let quote = lbPair.swapQuote(inAmount, swapForY, allowedSlippage, binArrays, isPartialFill, 0);
     expect(quote.binArraysPubkey.length).toEqual(1);
 
+    const binArrayToSwapPubkey = quote.binArraysPubkey[0];
+    const binArrayToSwap = await lbPair.program.account.binArray.fetch(binArrayToSwapPubkey);
+
     quote = lbPair.swapQuote(inAmount, swapForY, allowedSlippage, binArrays, isPartialFill, 3);
     expect(quote.binArraysPubkey.length).toEqual(4);
+
+    // expect binArrays are in correct order
+    expect(quote.binArraysPubkey[0]).toEqual(binArrayToSwapPubkey);
+
+    let lastBinArrayIdx = binArrayToSwap.index;
+    for (let i = 1; i < binArrays.length; i++) {
+      let assertBinArrayPubkey = quote.binArraysPubkey[i];
+
+      const assertBinArray = await lbPair.program.account.binArray.fetch(assertBinArrayPubkey);
+      console.log(assertBinArray.index);
+      if (swapForY) {
+        expect(assertBinArray.index).toEqual(lastBinArrayIdx.sub(new BN(1)));
+      } else {
+        expect(assertBinArray.index).toEqual(lastBinArrayIdx.add(new BN(1)));
+      }
+
+      lastBinArrayIdx = assertBinArray.index;
+    }
   });
 });

--- a/ts-client/src/test/sdk.test.ts
+++ b/ts-client/src/test/sdk.test.ts
@@ -2416,3 +2416,46 @@ describe("SDK test", () => {
     });
   });
 });
+
+describe("SDK Test with Mainnet RPC", () => {
+  let mainnetRpc: string = process.env.RPC || "https://api.mainnet-beta.solana.com";
+  let connection: Connection;
+
+  beforeAll(async () => {
+    connection = new Connection(mainnetRpc);
+  });
+
+  it("quote X -> Y with maxExtraBinArrays", async () => {
+    const pair = new PublicKey("5rCf1DM8LjKTw4YqhnoLcngyZYeNnQqztScTogYHAS6");
+    const lbPair = await DLMM.create(connection, pair);
+    const swapForY = true;
+    const inAmount = new BN(1 * 10 ** 9);
+    const allowedSlippage = new BN(2);
+    const isPartialFill = false;
+
+    const binArrays = await lbPair.getBinArrayForSwap(swapForY);
+    expect(binArrays.length).toBeGreaterThan(1);
+    let quote = lbPair.swapQuote(inAmount, swapForY, allowedSlippage, binArrays, isPartialFill, 0);
+    expect(quote.binArraysPubkey.length).toEqual(1);
+
+    quote = lbPair.swapQuote(inAmount, swapForY, allowedSlippage, binArrays, isPartialFill, 3);
+    expect(quote.binArraysPubkey.length).toEqual(4);
+  });
+
+  it("quote Y -> X with maxExtraBinArrays", async () => {
+    const pair = new PublicKey("5rCf1DM8LjKTw4YqhnoLcngyZYeNnQqztScTogYHAS6");
+    const lbPair = await DLMM.create(connection, pair);
+    const swapForY = true;
+    const inAmount = new BN(1_000 * 10 ** 6);
+    const allowedSlippage = new BN(2);
+    const isPartialFill = false;
+
+    const binArrays = await lbPair.getBinArrayForSwap(swapForY);
+    expect(binArrays.length).toBeGreaterThan(1);
+    let quote = lbPair.swapQuote(inAmount, swapForY, allowedSlippage, binArrays, isPartialFill, 0);
+    expect(quote.binArraysPubkey.length).toEqual(1);
+
+    quote = lbPair.swapQuote(inAmount, swapForY, allowedSlippage, binArrays, isPartialFill, 3);
+    expect(quote.binArraysPubkey.length).toEqual(4);
+  });
+});


### PR DESCRIPTION
Context:
in that example const binArrays = await dlmmPool.getBinArrayForSwap(swapYtoX); returns 4 binArrays for swap
But in that function: await dlmmPool.swapQuote() it only returns exact binArrays for swap, and in that case that is 1 binArray 
So if it is that reason, should we add one more field in dlmmPool.swapQuote() to indicate redundant binArrays we should add in swap?