### PR TITLE
fix: enable/disable mapping in set pair status permissionless

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+## @meteora-ag/dlmm [1.4.2] - PR #183
+
+### Added
+
+- Add `getCustomizablePermissionlessLbPairIfExists` function to fetch existing customizable permissionless LB pair
+
+### Fixed
+
+- Fix incorrect enable/disable mapping in `setPairStatusPermissionless`
+
 ## @meteora-ag/dlmm [1.4.1] - PR #182
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add `getCustomizablePermissionlessLbPairIfExists` function to fetch existing customizable permissionless LB pair
 
+### Changed
+
+- remove CU estimation for `seedLiquidity`
+
 ### Fixed
 
 - Fix incorrect enable/disable mapping in `setPairStatusPermissionless`

--- a/ts-client/package.json
+++ b/ts-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meteora-ag/dlmm",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/ts-client/src/dlmm/helpers/derive.ts
+++ b/ts-client/src/dlmm/helpers/derive.ts
@@ -142,7 +142,7 @@ export function derivePosition(
       lbPair.toBuffer(),
       base.toBuffer(),
       lowerBinIdBytes,
-      new Uint8Array(width.toBuffer("le", 4)),
+      new Uint8Array(width.toArrayLike(Buffer, "le", 4)),
     ],
     programId
   );

--- a/ts-client/src/dlmm/index.ts
+++ b/ts-client/src/dlmm/index.ts
@@ -4470,13 +4470,6 @@ export class DLMM {
 
       // Initialize bin arrays and initialize position account in 1 tx
       if (instructions.length > 1) {
-        // instructions.push(
-        //   await getEstimatedComputeUnitIxWithBuffer(
-        //     this.program.provider.connection,
-        //     instructions,
-        //     payer
-        //   )
-        // );
         initializeBinArraysAndPositionIxs.push(instructions);
         instructions = [];
       }


### PR DESCRIPTION
- fix: enable/disable mapping in set pair status permissionless
- Add `getCustomizablePermissionlessLbPairIfExists`