### PR TITLE
Fix: use `amount_left` instead of `amount_in` in `quote_exact_in`

### DIFF
--- a/commons/src/quote.rs
+++ b/commons/src/quote.rs
@@ -229,7 +229,7 @@ pub fn quote_exact_in(
                 total_fee = total_fee.checked_add(fee).context("MathOverflow")?;
             }
 
-            if amount_in > 0 {
+            if amount_left > 0 {
                 lb_pair.advance_active_bin(swap_for_y)?;
             }
         }


### PR DESCRIPTION
Replaced `amount_in > 0` with `amount_left > 0` in the `quote_exact_in` function.

The previous condition was using the original input amount (`amount_in`), which is not updated during the swap process. This could result in unnecessary calls to `advance_active_bin` even after the input has been fully consumed.

Using `amount_left` correctly reflects the remaining amount being processed and ensures swap logic behaves as expected.