### PR TITLE
fix: hardcoded values in swap parameters

### DIFF
--- a/ts-client/src/examples/example.ts
+++ b/ts-client/src/examples/example.ts
@@ -270,7 +270,7 @@ async function swap(dlmmPool: DLMM) {
     binArraysPubkey: swapQuote.binArraysPubkey,
     inAmount: swapAmount,
     lbPair: dlmmPool.pubkey,
-    user: feePayer.publicKey,
+    user: user.publicKey,
     minOutAmount: swapQuote.minOutAmount,
     outToken,
   });

--- a/ts-client/src/examples/example.ts
+++ b/ts-client/src/examples/example.ts
@@ -260,15 +260,19 @@ async function swap(dlmmPool: DLMM) {
 
   console.log("🚀 ~ swapQuote:", swapQuote);
 
+  const [inToken, outToken] = swapYtoX
+  ? [dlmmPool.tokenY.publicKey, dlmmPool.tokenX.publicKey]
+  : [dlmmPool.tokenX.publicKey, dlmmPool.tokenY.publicKey];
+
   // Swap
   const swapTx = await dlmmPool.swap({
-    inToken: dlmmPool.tokenX.publicKey,
+    inToken,
     binArraysPubkey: swapQuote.binArraysPubkey,
     inAmount: swapAmount,
     lbPair: dlmmPool.pubkey,
-    user: user.publicKey,
+    user: feePayer.publicKey,
     minOutAmount: swapQuote.minOutAmount,
-    outToken: dlmmPool.tokenY.publicKey,
+    outToken,
   });
 
   try {


### PR DESCRIPTION
The parameters in the dlmmPool.swap call are not taking in consideration the direction stated in swapYtoX boolean, as they are hardcoded, leading to reverts if the direction is not the hardcoded one.