### PR TITLE
fix: make feeOwner and decimal fields optional in DLMM SDK; add a missing quote at line 32 (all in types.py)

### DIFF
--- a/python-client/dlmm/dlmm/dlmm.py
+++ b/python-client/dlmm/dlmm/dlmm.py
@@ -6,7 +6,7 @@ from solders.pubkey import Pubkey
 from .utils import convert_to_transaction
 from .types import ActivationType, ActiveBin, FeeInfo, GetBins, GetPositionByUser, Position, PositionInfo, StrategyParameters, SwapQuote, LBPair, TokenReserve, DlmmHttpError as HTTPError
 
-API_URL = "localhost:3000"
+API_URL = "http://localhost:3000"
 
 class DLMM:
     '''

--- a/python-client/dlmm/dlmm/types.py
+++ b/python-client/dlmm/dlmm/types.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 from enum import Enum
 from solders.pubkey import Pubkey
-from typing import Any, List, TypedDict
+from typing import Any, List, TypedDict, Optional
 
 class DlmmHttpError(Exception):
     def __init__(self, message):
@@ -29,7 +29,7 @@ class ActivationType(Enum):
     Timestamp=1,
 
     def __str__(self) -> str:
-        return f"{self.value[1]}
+        return f"{self.value[1]}"
     
     def __repr__(self) -> str:
         return self.name
@@ -265,7 +265,7 @@ class LBPair:
     token_y_mint: str
     padding1: List[int]
     padding2: List[int]
-    fee_owner: Pubkey
+    fee_owner: Optional[Pubkey]
     base_key: str
 
     def __init__(self, data: dict) -> None:
@@ -281,7 +281,7 @@ class LBPair:
         self.token_y_mint = data["tokenYMint"]
         self.padding1 = data["padding1"]
         self.padding2 = data["padding2"]
-        self.fee_owner = Pubkey.from_string(data["feeOwner"])
+        self.fee_owner = Pubkey.from_string(data["feeOwner"]) if "feeOwner" in data else None
         self.base_key = data["baseKey"]
         
 @dataclass
@@ -289,13 +289,13 @@ class TokenReserve():
     public_key: Pubkey
     reserve: Pubkey
     amount: str
-    decimal: int
+    decimal: Optional[int]
 
     def __init__(self, data: dict) -> None:
         self.public_key = Pubkey.from_string(data["publicKey"])
         self.reserve = Pubkey.from_string(data["reserve"])
         self.amount = data["amount"]
-        self.decimal = data["decimal"]
+        self.decimal = data.get("decimal", 9)  # Default to 9 decimals if not provided
 
 @dataclass
 class PositionInfo():


### PR DESCRIPTION
**Summary**
This PR contains fixes for several issues that were causing crashes when the API didn't return certain fields, had missing token decimal values, used incorrect URL formats, or hit syntax errors in string formatting - making the SDK much more robust when working with different DLMM pools.

1. Fixed API URL Format (dlmm.py):

- Changed API_URL = "localhost:3000" to API_URL = "http://localhost:3000"
- Added required HTTP protocol prefix for proper URL construction

2. Fixed Missing Quote in String Literal (types.py):

- Fixed a syntax error at line 32 where a string literal was missing a closing quote
- Changed return f"{self.value[1]} to return f"{self.value[1]}"

3. Made feeOwner Field Optional (types.py):

- Added Optional import from typing module
- Modified LBPair class to handle cases where feeOwner is not provided
- Changed type from fee_owner: Pubkey to fee_owner: Optional[Pubkey]
- Added conditional check in constructor: self.fee_owner = Pubkey.from_string(data["feeOwner"]) if "feeOwner" in data else None

4. Made decimal Field Optional (types.py):

- Modified TokenReserve class to make the decimal field optional
- Changed type from decimal: int to decimal: Optional[int]
- Added default value for decimal when not provided: self.decimal = data.get("decimal", 9)