### PR TITLE
chore: remove redundant word in comment

### DIFF
--- a/python-client/dlmm/dlmm/dlmm.py
+++ b/python-client/dlmm/dlmm/dlmm.py
@@ -341,7 +341,7 @@ class DLMM:
             swap_Y_to_X (bool): Swap token X to Y when it is true, else reversed.
             allowed_slippage (int): Allowed slippage for the swap. Expressed in BPS. To convert from slippage percentage to BPS unit: SLIPPAGE_PERCENTAGE * 100
             binArrays (List[dict]): The list of bin arrays to use for the swap.
-            is_partial_filled (Optional[bool]): Flag to check whether the the swapQuote is partial fill.
+            is_partial_filled (Optional[bool]): Flag to check whether the swapQuote is partial fill.
         
         '''
         if type(amount) != int:

--- a/ts-client/src/dlmm/index.ts
+++ b/ts-client/src/dlmm/index.ts
@@ -4014,7 +4014,7 @@ export class DLMM {
    *    - `swapForY`: Swap token X to Y when it is true, else reversed.
    *    - `allowedSlippage`: Allowed slippage for the swap. Expressed in BPS. To convert from slippage percentage to BPS unit: SLIPPAGE_PERCENTAGE * 100
    *    - `binArrays`: binArrays for swapQuote.
-   *    - `isPartialFill`: Flag to check whether the the swapQuote is partial fill, default = false.
+   *    - `isPartialFill`: Flag to check whether the swapQuote is partial fill, default = false.
    *    - `maxExtraBinArrays`: Maximum number of extra binArrays to return
    * @returns {SwapQuote}
    *    - `consumedInAmount`: Amount of lamport to swap in


### PR DESCRIPTION
remove redundant word in comment