### PR TITLE
Python and TS SDK Fixes

### DIFF
--- a/python-client/dlmm/dlmm/dlmm.py
+++ b/python-client/dlmm/dlmm/dlmm.py
@@ -4,9 +4,9 @@ from typing import Dict, List, Optional
 from solana.transaction import Transaction
 from solders.pubkey import Pubkey
 from .utils import convert_to_transaction
-from .types import ActivationType, ActiveBin, FeeInfo, GetBins, GetPositionByUser, Position, PositionInfo, StrategyParameters, SwapQuote, LBPair, TokenReserve, DlmmHttpError as HTTPError
+from .types import ActivationType, ActiveBin, FeeInfo, GetBins, BinArray, Position, GetPositionByUser, Position, PositionInfo, StrategyParameters, SwapQuote, LBPair, TokenReserve, DlmmHttpError as HTTPError
 
-API_URL = "localhost:3000"
+API_URL = "http://localhost:3000"
 
 class DLMM:
     '''
@@ -304,7 +304,6 @@ class DLMM:
             raise HTTPError(f"Error connecting to DLMM: {e}")
 
     
-    # TODO: Add type for result
     def get_bin_array_for_swap(self, swap_Y_to_X: bool, count: Optional[int]=4) -> List[dict]:
         '''
         This function retrieves a specified number of `BinArrayAccount` objects from the blockchain for swap.
@@ -438,14 +437,13 @@ class DLMM:
         except requests.exceptions.ConnectionError as e:
             raise HTTPError(f"Error connecting to DLMM: {e}")
     
-    # TODO: Add type for result
-    def get_bin_arrays(self) -> List[dict]:
+    def get_bin_arrays(self) -> list[BinArray]:
         '''
         This function retrieves all bin arrays from the blockchain.
         '''
         try:
             result = self.__session.get(f"{API_URL}/dlmm/get-bin-arrays").json()
-            return result
+            return [BinArray(bin_data) for bin_data in result]
         except requests.exceptions.HTTPError as e:
             raise HTTPError(f"Error getting bin arrays: {e}")
         except requests.exceptions.ConnectionError as e:
@@ -771,7 +769,11 @@ class DLMM_CLIENT:
             session.headers.update({
                 'Content-type': 'application/json', 
                 'Accept': 'text/plain',
-                'rpc': rpc
+                'rpc': rpc,
+                'pool': "2EszZfwee7myuECGizcprwsC5jymGTVVEqPG5uVRRbmb"
+                # There needs to be some pool passed or else it errors
+                # Could fix the error in TS but would have to rewrite the handler
+
             })
             data = json.dumps({
                 "user": str(user)

--- a/python-client/dlmm/tests/test_lp_flow.py
+++ b/python-client/dlmm/tests/test_lp_flow.py
@@ -19,7 +19,9 @@ def test_flow():
     assert type(active_bin_price_per_token) == float
 
     user = Keypair.from_bytes([3, 65, 174, 194, 140, 162, 138, 46, 167, 188, 153, 227, 110, 110, 82, 167, 238, 92, 174, 250, 66, 104, 188, 196, 164, 72, 222, 202, 150, 52, 38, 249, 205, 59, 43, 173, 101, 40, 208, 183, 241, 9, 237, 75, 52, 240, 165, 65, 91, 247, 233, 207, 170, 155, 162, 181, 215, 135, 103, 2, 132, 32, 196, 16])
-    new_balance_position = Keypair.from_bytes([32, 144, 75, 246, 203, 27, 190, 52, 136, 171, 135, 250, 125, 246, 242, 26, 67, 40, 71, 23, 206, 192, 101, 86, 155, 59, 121, 96, 14, 59, 50, 215, 212, 236, 210, 249, 79, 133, 198, 35, 7, 150, 118, 47, 206, 4, 220, 255, 79, 208, 248, 233, 179, 231, 209, 204, 139, 232, 20, 116, 66, 48, 2, 49])
+
+    new_balance_position = Keypair()
+
     total_interval_range = 10
     max_bin_id = active_bin.bin_id + total_interval_range
     min_bin_id = active_bin.bin_id - total_interval_range
@@ -27,14 +29,14 @@ def test_flow():
     total_y_amount = total_x_amount * int(active_bin_price_per_token)
 
     position_tx = dlmm.initialize_position_and_add_liquidity_by_strategy(
-        new_balance_position.pubkey(), 
+        new_balance_position.pubkey(),
         user.pubkey(), 
         total_x_amount, 
         total_y_amount, 
         {
             "max_bin_id": max_bin_id, 
             "min_bin_id": min_bin_id, 
-            "strategy_type": StrategyType.SpotBalanced
+            "strategy_type": 0
         })
 
     assert isinstance(position_tx, Transaction)
@@ -65,8 +67,8 @@ def test_flow():
     if user_positions:
         bin_ids_to_remove = list(map(lambda x: x.bin_id, user_positions.position_data.position_bin_data))
         remove_liquidity = dlmm.remove_liqidity(
-            new_balance_position.pubkey(), 
-            user.pubkey(), 
+            new_balance_position.pubkey(),
+            user.pubkey(),
             bin_ids_to_remove,
             100*100,
             True

--- a/python-client/dlmm/tests/test_util_methods.py
+++ b/python-client/dlmm/tests/test_util_methods.py
@@ -1,7 +1,7 @@
 from dlmm.dlmm import DLMM, DLMM_CLIENT
 from solana.rpc.api import Client
 from solders.pubkey import Pubkey
-from dlmm.types import FeeInfo, GetBins
+from dlmm.types import FeeInfo, GetBins, Position
 from solders.keypair import Keypair
 from solana.transaction import Transaction
 
@@ -13,7 +13,9 @@ def test_util_methods():
     assert isinstance(dlmm, DLMM)
 
     user = Keypair.from_bytes([3, 65, 174, 194, 140, 162, 138, 46, 167, 188, 153, 227, 110, 110, 82, 167, 238, 92, 174, 250, 66, 104, 188, 196, 164, 72, 222, 202, 150, 52, 38, 249, 205, 59, 43, 173, 101, 40, 208, 183, 241, 9, 237, 75, 52, 240, 165, 65, 91, 247, 233, 207, 170, 155, 162, 181, 215, 135, 103, 2, 132, 32, 196, 16])
-    new_balance_position = Keypair.from_bytes([32, 144, 75, 246, 203, 27, 190, 52, 136, 171, 135, 250, 125, 246, 242, 26, 67, 40, 71, 23, 206, 192, 101, 86, 155, 59, 121, 96, 14, 59, 50, 215, 212, 236, 210, 249, 79, 133, 198, 35, 7, 150, 118, 47, 206, 4, 220, 255, 79, 208, 248, 233, 179, 231, 209, 204, 139, 232, 20, 116, 66, 48, 2, 49])
+
+    new_balance_position = Keypair()
+    #new_balance_position = Keypair.from_bytes([32, 144, 75, 246, 203, 27, 190, 52, 136, 171, 135, 250, 125, 246, 242, 26, 67, 40, 71, 23, 206, 192, 101, 86, 155, 59, 121, 96, 14, 59, 50, 215, 212, 236, 210, 249, 79, 133, 198, 35, 7, 150, 118, 47, 206, 4, 220, 255, 79, 208, 248, 233, 179, 231, 209, 204, 139, 232, 20, 116, 66, 48, 2, 49])
 
     bin_arrays = dlmm.get_bin_arrays()
     assert type(bin_arrays) == list
@@ -24,8 +26,9 @@ def test_util_methods():
     dynamic_fee = dlmm.get_dynamic_fee()
     assert type(dynamic_fee) == float
 
-    check_bin = bin_arrays[0]["account"]["bins"][0]
-    bin_id = dlmm.get_bin_id_from_price(float(check_bin["price"]), True)
+    check_bin = bin_arrays[0].account.bins[0]
+
+    bin_id = dlmm.get_bin_id_from_price(float(check_bin.price), True)
     assert isinstance(bin_id, int) or bin_id is None
 
     bins_around_active = dlmm.get_bins_around_active_bin(0, 0)
@@ -34,7 +37,7 @@ def test_util_methods():
     bins_between_upper_lower = dlmm.get_bins_between_lower_and_upper_bound(0, 2)
     assert isinstance(bins_between_upper_lower, GetBins)
 
-    bins_between_min_max = dlmm.get_bins_between_min_and_max_price(0.0, 50.0)
+    bins_between_min_max = dlmm.get_bins_between_min_and_max_price(0.1, 50.0)
     assert isinstance(bins_between_min_max, GetBins)
 
     positions = dlmm.get_positions_by_user_and_lb_pair(user.pubkey())
@@ -45,6 +48,11 @@ def test_util_methods():
 
         claim_swap_fee = dlmm.claim_swap_fee(new_balance_position.pubkey(), user_positions)
         assert isinstance(claim_swap_fee, Transaction)
+
+    all_positions = DLMM_CLIENT.get_all_lb_pair_positions_by_user(user.pubkey(), RPC)
+
+    assert isinstance(all_positions, dict) and len(all_positions) > 0
+
 
 
 

--- a/ts-client/src/server/index.ts
+++ b/ts-client/src/server/index.ts
@@ -69,14 +69,14 @@ app.get("/dlmm/create", async (req, res) => {
 //   }
 // })
 
-app.get("/dlmm/get-all-lb-pair-positions-by-user", async (req, res) => {
+app.post("/dlmm/get-all-lb-pair-positions-by-user", async (req, res) => {
   try {
     const userPublicKey = new PublicKey(req.body.user);
     const positions = await DLMM.getAllLbPairPositionsByUser(
       req.connect,
       userPublicKey
     );
-    return res.status(200).send(safeStringify(positions));
+    return res.status(200).send(safeStringify(Object.fromEntries(positions)));
   } catch (error) {
     console.log(error);
     return res.status(400).send(error);


### PR DESCRIPTION
Types:
Added Union type to allow for None types for certain objects
Allowed fee_owner, decimals to be none, since there are times the rest of the data is good
Added data classes for Bin, BinArray, BinAccount
Added hex conversions for fees and such

DLMM:
Implemented the new data classes (removed TODO)
Passed a random pool to get_all_lb_pair_positions_by_user to fix init error in TS
Changed API_URL to "http://localhost:3000/ adding the http://

test_lp_flow
Randomly generated position account for reusability

test_util_methods
Randomly generated position account for reusability
Added new test case for a new function that was pushed 5 months ago

server/index.ts
dlmm/get-all-lb-pair-positions-by-user was supposed to be post, fixed
Map object could not stringify without Object.fromEntries, fixed
