### PR TITLE
fix(dlmm): remove duplicated instructions in remove liquidity

### DIFF
--- a/ts-client/src/dlmm/index.ts
+++ b/ts-client/src/dlmm/index.ts
@@ -4185,7 +4185,9 @@ export class DLMM {
     const chunkedBinRange = chunkBinRange(fromBinId, toBinId);
     const groupedInstructions: TransactionInstruction[][] = [];
 
-    for (const { lowerBinId, upperBinId } of chunkedBinRange) {
+    for (let i = 0; i < chunkedBinRange.length; i++) {
+      const { lowerBinId, upperBinId } = chunkedBinRange[i];
+      const isFirstChunk = i === 0;
       const binArrayAccountsMeta = getBinArrayAccountMetasCoverage(
         new BN(lowerBinId),
         new BN(upperBinId),
@@ -4222,8 +4224,11 @@ export class DLMM {
           .remainingAccounts(binArrayAccountsMeta)
           .instruction();
 
-        preInstructions.push(createFeeOwnerTokenXIx);
-        preInstructions.push(createFeeOwnerTokenYIx);
+        if (isFirstChunk) {
+          preInstructions.push(createFeeOwnerTokenXIx);
+          preInstructions.push(createFeeOwnerTokenYIx);
+        }
+
         postInstructions.push(claimSwapFeeIx);
 
         for (let i = 0; i < 2; i++) {
@@ -4296,9 +4301,11 @@ export class DLMM {
         closeWrappedSOLIx && postInstructions.push(closeWrappedSOLIx);
       }
 
-      preInstructions.push(createUserTokenXIx);
-      preInstructions.push(createUserTokenYIx);
-
+      if (isFirstChunk) {
+        preInstructions.push(createUserTokenXIx);
+        preInstructions.push(createUserTokenYIx);
+      }
+      
       const binArrayBitmapExtension = this.binArrayBitmapExtension
         ? this.binArrayBitmapExtension.publicKey
         : this.program.programId;

--- a/ts-client/src/dlmm/index.ts
+++ b/ts-client/src/dlmm/index.ts
@@ -4185,6 +4185,9 @@ export class DLMM {
     const chunkedBinRange = chunkBinRange(fromBinId, toBinId);
     const groupedInstructions: TransactionInstruction[][] = [];
 
+    const { slices, accounts: transferHookAccounts } =
+      this.getPotentialToken2022IxDataAndAccounts(ActionType.Liquidity);
+
     for (let i = 0; i < chunkedBinRange.length; i++) {
       const { lowerBinId, upperBinId } = chunkedBinRange[i];
       const isFirstChunk = i === 0;
@@ -4194,9 +4197,6 @@ export class DLMM {
         this.pubkey,
         this.program.programId
       );
-
-      const { slices, accounts: transferHookAccounts } =
-        this.getPotentialToken2022IxDataAndAccounts(ActionType.Liquidity);
 
       const preInstructions: Array<TransactionInstruction> = [];
       const postInstructions: Array<TransactionInstruction> = [];

--- a/ts-client/src/dlmm/index.ts
+++ b/ts-client/src/dlmm/index.ts
@@ -4278,19 +4278,22 @@ export class DLMM {
           postInstructions.push(claimRewardIx);
         }
 
-        const closePositionIx = await this.program.methods
-          .closePositionIfEmpty()
-          .accountsPartial({
-            rentReceiver: owner, // Must be position owner
-            position,
-            sender: user,
-          })
-          .instruction();
+        if (isFirstChunk) {
+          const closePositionIx = await this.program.methods
+            .closePositionIfEmpty()
+            .accountsPartial({
+              rentReceiver: owner, // Must be position owner
+              position,
+              sender: user,
+            })
+            .instruction();
 
-        postInstructions.push(closePositionIx);
+          postInstructions.push(closePositionIx);
+        }
       }
 
       if (
+        isFirstChunk &&
         [
           this.tokenX.publicKey.toBase58(),
           this.tokenY.publicKey.toBase58(),


### PR DESCRIPTION
In the `dlmm.removeLiquidity` function, the create ATA for the user and fee owner instructions are added to each bin range transaction, so, the instructions are unnecessary duplicated.

In this PR I propose to only add the create ATA ix in the first iteration of the bin range for loop.

Despite the createATA ixs being idempotent, it's taking unnecessary space in the final transaction.