### PR TITLE
fix(server): createCustomizablePermissionlessLbPair type error

### DIFF
--- a/ts-client/src/server/index.ts
+++ b/ts-client/src/server/index.ts
@@ -96,11 +96,10 @@ app.post(
       const activationType = parseInt(req.body.activationType);
       const hasAlphaVault = Boolean(req.body.hasAlphaVault);
       const creatorKey = new PublicKey(req.body.creatorKey);
-      const functionType = FunctionType.LiquidityMining;
       const activationPoint =
         req.body.activationPoint !== null
           ? new BN(req.body.activationPoint)
-          : null;
+          : undefined;
       const transaction = DLMM.createCustomizablePermissionlessLbPair(
         req.connect,
         binStep,
@@ -111,7 +110,6 @@ app.post(
         activationType,
         hasAlphaVault,
         creatorKey,
-        functionType,
         activationPoint
       );
       return res.status(200).send(safeStringify(transaction));


### PR DESCRIPTION
In this PR I address a typescript error in the server route `/dlmm/create-customizable-permissionless-lb-pair`

`DLMM.createCustomizablePermissionlessLbPair` doesn't accept any functionType argument.

And activationPoint argument types are `BN` or `undefined`, not `null`.

Example of how the python client currently uses this server route:
```python
        try:
            data = json.dumps({
                "binStep": bin_step,
                "tokenX": str(token_x),
                "tokenY": str(token_y),
                "activeId": active_id,
                "feeBps": fee_bps,
                "activationType": activation_type,
                "hasAlphaVault": has_alpha_vault,
                "creatorKey": str(creator_key),
                "activationPoint": activation_point
            })
            result = requests.post(f"{API_URL}/dlmm/create-customizable-permissionless-lb-pair", data=data).json()
            return convert_to_transaction(result)
```

