### PR TITLE
fix: add null check for feeInfos in processPosition

### DIFF
--- a/ts-client/src/dlmm/index.ts
+++ b/ts-client/src/dlmm/index.ts
@@ -7625,29 +7625,31 @@ export class DLMM {
 
       const feeInfo = feeInfos[idx];
 
-      const newFeeX = posShare.isZero()
-        ? new BN(0)
-        : mulShr(
-            posShares[idx].shrn(SCALE_OFFSET),
-            bin.feeAmountXPerTokenStored.sub(feeInfo.feeXPerTokenComplete),
-            SCALE_OFFSET,
-            Rounding.Down
-          );
+      if (feeInfo) {
+        const newFeeX = posShare.isZero()
+          ? new BN(0)
+          : mulShr(
+              posShares[idx].shrn(SCALE_OFFSET),
+              bin.feeAmountXPerTokenStored.sub(feeInfo.feeXPerTokenComplete),
+              SCALE_OFFSET,
+              Rounding.Down
+            );
 
-      const newFeeY = posShare.isZero()
-        ? new BN(0)
-        : mulShr(
-            posShares[idx].shrn(SCALE_OFFSET),
-            bin.feeAmountYPerTokenStored.sub(feeInfo.feeYPerTokenComplete),
-            SCALE_OFFSET,
-            Rounding.Down
-          );
+        const newFeeY = posShare.isZero()
+          ? new BN(0)
+          : mulShr(
+              posShares[idx].shrn(SCALE_OFFSET),
+              bin.feeAmountYPerTokenStored.sub(feeInfo.feeYPerTokenComplete),
+              SCALE_OFFSET,
+              Rounding.Down
+            );
 
-      const claimableFeeX = newFeeX.add(feeInfo.feeXPending);
-      const claimableFeeY = newFeeY.add(feeInfo.feeYPending);
+        const claimableFeeX = newFeeX.add(feeInfo.feeXPending);
+        const claimableFeeY = newFeeY.add(feeInfo.feeYPending);
 
-      feeX = feeX.add(claimableFeeX);
-      feeY = feeY.add(claimableFeeY);
+        feeX = feeX.add(claimableFeeX);
+        feeY = feeY.add(claimableFeeY);
+      }
 
       const claimableRewardsInBin = [new BN(0), new BN(0)];
 


### PR DESCRIPTION
## Summary

Fixes a crash in `DLMM.getAllLbPairPositionsByUser()` when processing positions where the number of bins exceeds the `feeInfos` array length.

## Problem

The `processPosition` method accesses `feeInfos[idx]` without checking if the index exists. When `feeInfos` has fewer entries than the bins array, this causes:

```
Cannot read properties of undefined (reading 'feeAmountXPerTokenStored')
```

This crashes the entire `getAllLbPairPositionsByUser` call, making it impossible to fetch any positions for affected wallets.

## Fix

Wrap the fee calculation block in a null check for `feeInfo`. When `feeInfo` is undefined, fee calculations are skipped and fees default to zero — matching the behavior already used in the other `feeInfo` access at line ~4071 which already does `feeInfo &&` checks.

## Testing

- The fix aligns with the existing null-safe pattern used in the same codebase (line ~4071)
- Positions without fee data will show zero fees instead of crashing

Closes #245