### PR TITLE
fix: rebalance single bin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+## @meteora-ag/dlmm [1.9.7] - [PR #286](https://github.com/MeteoraAg/dlmm-sdk/pull/286)
+
+### Fixed
+
+- Allow `dlmm.simulateRebalancePosition` on single bin
+
 ## @meteora-ag/dlmm [1.9.6] - [PR #285](https://github.com/MeteoraAg/dlmm-sdk/pull/285)
 
 ### Fixed

--- a/ts-client/package.json
+++ b/ts-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meteora-ag/dlmm",
-  "version": "1.9.6",
+  "version": "1.9.7",
   "description": "",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/ts-client/src/dlmm/helpers/rebalance/rebalancePosition.ts
+++ b/ts-client/src/dlmm/helpers/rebalance/rebalancePosition.ts
@@ -954,7 +954,7 @@ function validateAndSortRebalanceDeposit(deposits: RebalanceWithDeposit[]) {
   );
 
   for (const deposit of deposits) {
-    if (deposit.minDeltaId.gte(deposit.maxDeltaId)) {
+    if (deposit.minDeltaId.gt(deposit.maxDeltaId)) {
       throw "Invalid minDeltaId or maxDeltaId";
     }
   }

--- a/ts-client/src/test/rebalance.test.ts
+++ b/ts-client/src/test/rebalance.test.ts
@@ -353,7 +353,7 @@ describe("Rebalance", () => {
     }
   });
 
-  it.only("Rebalance with single bin deposit", async () => {
+  it("Rebalance with single bin deposit", async () => {
     const dlmm = await DLMM.create(connection, lbPairPubkey, {
       cluster: "localhost",
     });

--- a/ts-client/src/test/rebalance.test.ts
+++ b/ts-client/src/test/rebalance.test.ts
@@ -353,6 +353,135 @@ describe("Rebalance", () => {
     }
   });
 
+  it.only("Rebalance with single bin deposit", async () => {
+    const dlmm = await DLMM.create(connection, lbPairPubkey, {
+      cluster: "localhost",
+    });
+
+    for (const strategy of strategySet) {
+      const positionKeypair = Keypair.generate();
+
+      const initPositionTx = await dlmm.createEmptyPosition({
+        positionPubKey: positionKeypair.publicKey,
+        user: keypair.publicKey,
+        minBinId: dlmm.lbPair.activeId - 30,
+        maxBinId: dlmm.lbPair.activeId + 30,
+      });
+
+      await sendAndConfirmTransaction(connection, initPositionTx, [
+        positionKeypair,
+        keypair,
+      ]);
+
+      const beforePositionLamports = await connection
+        .getAccountInfo(positionKeypair.publicKey)
+        .then((account) => account.lamports);
+
+      const beforePosition = await dlmm.getPosition(positionKeypair.publicKey);
+
+      const strategyParamBuilder =
+        getLiquidityStrategyParameterBuilder(strategy);
+
+      const minDeltaId = new BN(0);
+      const maxDeltaId = new BN(0);
+      const amountX = new BN(10_000_000);
+      const amountY = new BN(10_000_000);
+      const favorXInActiveBin = false;
+
+      const { x0, y0, deltaX, deltaY } = buildLiquidityStrategyParameters(
+        amountX,
+        amountY,
+        minDeltaId,
+        maxDeltaId,
+        new BN(dlmm.lbPair.binStep),
+        favorXInActiveBin,
+        new BN(dlmm.lbPair.activeId),
+        strategyParamBuilder
+      );
+
+      const { simulationResult, rebalancePosition } =
+        await dlmm.simulateRebalancePosition(
+          positionKeypair.publicKey,
+          beforePosition.positionData,
+          true,
+          true,
+          [
+            {
+              x0,
+              y0,
+              deltaX,
+              deltaY,
+              minDeltaId,
+              maxDeltaId,
+              favorXInActiveBin,
+            },
+          ],
+          [
+            {
+              minBinId: new BN(beforePosition.positionData.lowerBinId),
+              maxBinId: new BN(beforePosition.positionData.upperBinId),
+              bps: new BN(BASIS_POINT_MAX),
+            },
+          ]
+        );
+
+      const { initBinArrayInstructions, rebalancePositionInstruction } =
+        await dlmm.rebalancePosition(
+          { simulationResult, rebalancePosition },
+          new BN(0)
+        );
+
+      const { lastValidBlockHeight, blockhash } =
+        await connection.getLatestBlockhash();
+
+      await Promise.all(
+        initBinArrayInstructions.map((ix) => {
+          const transaction = new Transaction({
+            lastValidBlockHeight,
+            blockhash,
+          }).add(ix);
+
+          return sendAndConfirmTransaction(connection, transaction, [keypair]);
+        })
+      );
+
+      const rebalanceTx = new Transaction({
+        lastValidBlockHeight,
+        blockhash,
+      }).add(...rebalancePositionInstruction);
+
+      await sendAndConfirmTransaction(connection, rebalanceTx, [keypair]).then(
+        console.log
+      );
+
+      const afterPositionLamports = await connection
+        .getAccountInfo(positionKeypair.publicKey)
+        .then((account) => account.lamports);
+      const afterPosition = await dlmm.getPosition(positionKeypair.publicKey);
+
+      assertEqRebalanceSimulationWithActualResult(
+        rebalancePosition,
+        afterPosition
+      );
+
+      const rentalChanges = new BN(afterPositionLamports).sub(
+        new BN(beforePositionLamports)
+      );
+
+      expect(rentalChanges.toString()).toBe(
+        simulationResult.rentalCostLamports.toString()
+      );
+
+      const [_beforeWidth, afterWidth] = getBeforeAfterPositionWidth(
+        beforePosition,
+        afterPosition
+      );
+
+      expect(afterWidth).toBe(1);
+      await dlmm.refetchStates();
+    }
+  });
+
   it("Rebalance with only deposit and auto expand position", async () => {
     const dlmm = await DLMM.create(connection, lbPairPubkey, {
       cluster: "localhost",


### PR DESCRIPTION
In zap-sdk we call `simulateRebalancePosition` which currently throws the error of `Invalid minDeltaId or maxDeltaId`

https://github.com/MeteoraAg/zap-sdk/blob/main/src/zap.ts#L1878

This PR changes the underlying function to allow `simulateRebalancePosition` to be called when the position is a single bin (`minDeltaId` == `maxDeltaId`)