### PR TITLE
fix/fix bitmap extension account handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+## @meteora-ag/dlmm [1.9.10] - [PR #293](https://github.com/MeteoraAg/dlmm-sdk/pull/292)
+
+### Fixed
+
+ - Fixed a missing Rent account in all `initializeBinArrayBitmapExtension` callsites, which caused failures in `chunkDepositWithRebalanceEndpoint`, `seedLiquidity`, `seedLiquiditySingleBin`, `syncWithMarketPrice`, `rebalancePosition`, and `placeLimitOrder` when the pool traded outside the default bin array bitmap.
+
 ## @meteora-ag/dlmm [1.9.9] - [PR #293](https://github.com/MeteoraAg/dlmm-sdk/pull/290)
 
 ### Fixed

--- a/ts-client/package.json
+++ b/ts-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meteora-ag/dlmm",
-  "version": "1.9.9",
+  "version": "1.9.10",
   "description": "",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/ts-client/src/dlmm/helpers/index.ts
+++ b/ts-client/src/dlmm/helpers/index.ts
@@ -19,6 +19,7 @@ import {
   Connection,
   GetProgramAccountsFilter,
   PublicKey,
+  SYSVAR_RENT_PUBKEY,
   SystemProgram,
   TransactionInstruction,
 } from "@solana/web3.js";
@@ -730,6 +731,7 @@ export async function chunkDepositWithRebalanceEndpoint(
           binArrayBitmapExtension: bitmapPubkey,
           lbPair: dlmm.pubkey,
           funder: payer,
+          rent: SYSVAR_RENT_PUBKEY,
         })
         .instruction();
 

--- a/ts-client/src/dlmm/index.ts
+++ b/ts-client/src/dlmm/index.ts
@@ -4850,8 +4850,12 @@ export class DLMM {
       preInstructions.push(createUserTokenXIx);
       preInstructions.push(createUserTokenYIx);
 
-      const binArrayBitmapExtension = this.binArrayBitmapExtension
-        ? this.binArrayBitmapExtension.publicKey
+      // Some corrupted bitmap extension accounts were initialized with the default
+      // lbPair; ignore them so remove-liquidity uses the program id fallback.
+      const binArrayBitmapExtension =
+        this.binArrayBitmapExtension &&
+        !this.binArrayBitmapExtension.account.lbPair.equals(PublicKey.default)
+          ? this.binArrayBitmapExtension.publicKey
         : this.program.programId;
 
       const instructions = [...preInstructions];
@@ -6475,6 +6479,7 @@ export class DLMM {
                     binArrayBitmapExtension,
                     funder: payer,
                     lbPair: this.pubkey,
+                    rent: SYSVAR_RENT_PUBKEY,
                   })
                   .instruction(),
               );
@@ -6725,6 +6730,7 @@ export class DLMM {
               binArrayBitmapExtension,
               funder: payer,
               lbPair: this.pubkey,
+              rent: SYSVAR_RENT_PUBKEY,
             })
             .instruction(),
         );
@@ -7246,6 +7252,7 @@ export class DLMM {
             binArrayBitmapExtension: binArrayBitMapExtensionPubkey,
             funder: owner,
             lbPair: this.pubkey,
+            rent: SYSVAR_RENT_PUBKEY,
           })
           .instruction();
         preInstructions.push(initializeBitmapExtensionIx);
@@ -7819,6 +7826,7 @@ export class DLMM {
             binArrayBitmapExtension: binArrayBitmap,
             funder: owner,
             lbPair: this.pubkey,
+            rent: SYSVAR_RENT_PUBKEY,
           })
           .preInstructions([
             ComputeBudgetProgram.setComputeUnitLimit({
@@ -8110,6 +8118,7 @@ export class DLMM {
           binArrayBitmapExtension: binArrayBitmapExtension,
           funder: owner,
           lbPair: this.pubkey,
+          rent: SYSVAR_RENT_PUBKEY,
         })
         .instruction();
 

--- a/ts-client/src/dlmm/index.ts
+++ b/ts-client/src/dlmm/index.ts
@@ -4850,12 +4850,8 @@ export class DLMM {
       preInstructions.push(createUserTokenXIx);
       preInstructions.push(createUserTokenYIx);
 
-      // Some corrupted bitmap extension accounts were initialized with the default
-      // lbPair; ignore them so remove-liquidity uses the program id fallback.
-      const binArrayBitmapExtension =
-        this.binArrayBitmapExtension &&
-        !this.binArrayBitmapExtension.account.lbPair.equals(PublicKey.default)
-          ? this.binArrayBitmapExtension.publicKey
+      const binArrayBitmapExtension = this.binArrayBitmapExtension
+        ? this.binArrayBitmapExtension.publicKey
         : this.program.programId;
 
       const instructions = [...preInstructions];


### PR DESCRIPTION
Pass `SYSVAR_RENT_PUBKEY` to bitmap extension instructions and ignore corrupted extension accounts with the default `lbPair` when selecting the remove-liquidity fallback.