### PR TITLE
[feat]: added getPositionsByUserAndTokenAddress and getLimitOrdersByUserAndTokenAddress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+## @meteora-ag/dlmm [1.9.13]
+
+### Added
+
+- Added `getPositionsByUserAndTokenAddress` static method to retrieve a user's positions across all DLMM pools that contain a given token mint (as either `tokenXMint` or `tokenYMint`).
+- Added `getLimitOrdersByUserAndTokenAddress` static method to retrieve a user's limit orders across all DLMM pools that contain a given token mint (as either `tokenXMint` or `tokenYMint`), grouped by LB pair. Also exported a new `LimitOrderInfo` type.
+
 ## @meteora-ag/dlmm [1.9.12] - [PR #298](https://github.com/MeteoraAg/dlmm-sdk/pull/298)
 
 ### Fixed
@@ -36,7 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
- - Fixed a missing Rent account in all `initializeBinArrayBitmapExtension` callsites, which caused failures in `chunkDepositWithRebalanceEndpoint`, `seedLiquidity`, `seedLiquiditySingleBin`, `syncWithMarketPrice`, `rebalancePosition`, and `placeLimitOrder` when the pool traded outside the default bin array bitmap.
+- Fixed a missing Rent account in all `initializeBinArrayBitmapExtension` callsites, which caused failures in `chunkDepositWithRebalanceEndpoint`, `seedLiquidity`, `seedLiquiditySingleBin`, `syncWithMarketPrice`, `rebalancePosition`, and `placeLimitOrder` when the pool traded outside the default bin array bitmap.
 
 ## @meteora-ag/dlmm [1.9.9] - [PR #293](https://github.com/MeteoraAg/dlmm-sdk/pull/290)
 

--- a/ts-client/README.md
+++ b/ts-client/README.md
@@ -44,7 +44,7 @@ const dlmmPool = await DLMM.createMultiple(connection, [USDC_USDT_POOL, ...]);
 const activeBin = await dlmmPool.getActiveBin();
 const activeBinPriceLamport = activeBin.price;
 const activeBinPricePerToken = dlmmPool.fromPricePerLamport(
-  Number(activeBin.price)
+  Number(activeBin.price),
 );
 ```
 
@@ -64,7 +64,7 @@ const totalYAmount = autoFillYByStrategy(
   activeBin.yAmount,
   minBinId,
   maxBinId,
-  StrategyType.Spot // can be StrategyType.Spot, StrategyType.BidAsk, StrategyType.Curve
+  StrategyType.Spot, // can be StrategyType.Spot, StrategyType.BidAsk, StrategyType.Curve
 );
 const newBalancePosition = new Keypair();
 
@@ -86,7 +86,7 @@ try {
   const createBalancePositionTxHash = await sendAndConfirmTransaction(
     connection,
     createPositionTx,
-    [user, newBalancePosition]
+    [user, newBalancePosition],
   );
 } catch (error) {}
 ```
@@ -120,7 +120,7 @@ try {
   const createBalancePositionTxHash = await sendAndConfirmTransaction(
     connection,
     createPositionTx,
-    [user, newImbalancePosition]
+    [user, newImbalancePosition],
   );
 } catch (error) {}
 ```
@@ -154,7 +154,7 @@ try {
   const createOneSidePositionTxHash = await sendAndConfirmTransaction(
     connection,
     createPositionTx,
-    [user, newOneSidePosition]
+    [user, newOneSidePosition],
   );
 } catch (error) {}
 ```
@@ -163,7 +163,7 @@ try {
 
 ```ts
 const { userPositions } = await dlmmPool.getPositionsByUserAndLbPair(
-  user.publicKey
+  user.publicKey,
 );
 const binData = userPositions[0].positionData.positionBinData;
 ```
@@ -184,7 +184,7 @@ const totalYAmount = autoFillYByStrategy(
   activeBin.yAmount,
   minBinId,
   maxBinId,
-  StrategyType.Spot // can be StrategyType.Spot, StrategyType.BidAsk, StrategyType.Curve
+  StrategyType.Spot, // can be StrategyType.Spot, StrategyType.BidAsk, StrategyType.Curve
 );
 
 // Add Liquidity to existing position
@@ -204,7 +204,7 @@ try {
   const addLiquidityTxHash = await sendAndConfirmTransaction(
     connection,
     addLiquidityTx,
-    [user]
+    [user],
   );
 } catch (error) {}
 ```
@@ -213,11 +213,11 @@ try {
 
 ```ts
 const userPosition = userPositions.find(({ publicKey }) =>
-  publicKey.equals(newBalancePosition.publicKey)
+  publicKey.equals(newBalancePosition.publicKey),
 );
 // Remove Liquidity
 const binIdsToRemove = userPosition.positionData.positionBinData.map(
-  (bin) => bin.binId
+  (bin) => bin.binId,
 );
 const removeLiquidityTx = await dlmmPool.removeLiquidity({
   position: userPosition.publicKey,
@@ -225,7 +225,7 @@ const removeLiquidityTx = await dlmmPool.removeLiquidity({
   fromBinId: binIdsToRemove[0],
   toBinId: binIdsToRemove[binIdsToRemove.length - 1],
   liquiditiesBpsToRemove: new Array(binIdsToRemove.length).fill(
-    new BN(100 * 100)
+    new BN(100 * 100),
   ), // 100% (range from 0 to 100)
   shouldClaimAndClose: true, // should claim swap fee and close position together
 });
@@ -238,7 +238,7 @@ try {
       connection,
       tx,
       [user],
-      { skipPreflight: false, preflightCommitment: "singleGossip" }
+      { skipPreflight: false, preflightCommitment: "singleGossip" },
     );
   }
 } catch (error) {}
@@ -258,7 +258,7 @@ async function claimFee(dlmmPool: DLMM) {
       const claimFeeTxHash = await sendAndConfirmTransaction(
         connection,
         claimFeeTx,
-        [user]
+        [user],
       );
     }
   } catch (error) {}
@@ -278,7 +278,7 @@ try {
     connection,
     closePositionTx,
     [user],
-    { skipPreflight: false, preflightCommitment: "singleGossip" }
+    { skipPreflight: false, preflightCommitment: "singleGossip" },
   );
 } catch (error) {}
 ```
@@ -295,7 +295,7 @@ const swapQuote = await dlmmPool.swapQuote(
   swapAmount,
   swapYtoX,
   new BN(1),
-  binArrays
+  binArrays,
 );
 
 // Swap
@@ -318,15 +318,17 @@ try {
 
 ## Static functions
 
-| Function                      | Description                                                                        | Return                               |
-| ----------------------------- | ---------------------------------------------------------------------------------- | ------------------------------------ |
-| `create`                      | Given the DLMM address, create an instance to access the state and functions       | `Promise<DLMM>`                      |
-| `createMultiple`              | Given a list of DLMM addresses, create instances to access the state and functions | `Promise<Array<DLMM>>`               |
-| `getAllPresetParameters`      | Get all the preset params (use to create DLMM pool)                                | `Promise<PresetParams>`              |
-| `createPermissionLbPair`      | Create DLMM Pool                                                                   | `Promise<Transcation>`               |
-| `getClaimableLMReward`        | Get Claimable LM reward for a position                                             | `Promise<LMRewards>`                 |
-| `getClaimableSwapFee`         | Get Claimable Swap Fee for a position                                              | `Promise<SwapFee>`                   |
-| `getAllLbPairPositionsByUser` | Get user's all positions for all DLMM pools                                        | `Promise<Map<string, PositionInfo>>` |
+| Function                            | Description                                                                        | Return                               |
+| ----------------------------------- | ---------------------------------------------------------------------------------- | ------------------------------------ |
+| `create`                            | Given the DLMM address, create an instance to access the state and functions       | `Promise<DLMM>`                      |
+| `createMultiple`                    | Given a list of DLMM addresses, create instances to access the state and functions | `Promise<Array<DLMM>>`               |
+| `getAllPresetParameters`            | Get all the preset params (use to create DLMM pool)                                | `Promise<PresetParams>`              |
+| `createPermissionLbPair`            | Create DLMM Pool                                                                   | `Promise<Transcation>`               |
+| `getClaimableLMReward`              | Get Claimable LM reward for a position                                             | `Promise<LMRewards>`                 |
+| `getClaimableSwapFee`               | Get Claimable Swap Fee for a position                                              | `Promise<SwapFee>`                   |
+| `getAllLbPairPositionsByUser`       | Get user's all positions for all DLMM pools                                        | `Promise<Map<string, PositionInfo>>` |
+| `getPositionsByUserAndTokenAddress` | Get user's positions across all DLMM pools that contain a given token mint         | `Promise<Map<string, PositionInfo>>` |
+| `getLimitOrdersByUserAndTokenAddress` | Get user's limit orders across all DLMM pools that contain a given token mint, grouped by LB pair | `Promise<Map<string, LimitOrderInfo>>` |
 
 ## DLMM instance functions
 

--- a/ts-client/package.json
+++ b/ts-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meteora-ag/dlmm",
-  "version": "1.9.12",
+  "version": "1.9.13",
   "description": "",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/ts-client/src/dlmm/index.ts
+++ b/ts-client/src/dlmm/index.ts
@@ -197,6 +197,7 @@ import {
   MEMO_PROGRAM_ID,
   PairLockInfo,
   PairStatus,
+  LimitOrderInfo,
   PairType,
   PositionBinData,
   PositionData,
@@ -1170,6 +1171,280 @@ export class DLMM {
     }
 
     return positionsMap;
+  }
+
+  /**
+   * The function `getPositionsByUserAndTokenAddress` retrieves all of a user's positions across every
+   * DLMM pool that includes the given token mint as either the X or Y token.
+   * @param {Connection} connection - The `connection` parameter is an instance of the `Connection`
+   * class, which represents the connection to the Solana blockchain.
+   * @param {PublicKey} userPubKey - The user's wallet public key.
+   * @param {PublicKey} tokenMint - The token mint used to filter pools. Only positions in pools whose
+   * `tokenXMint` or `tokenYMint` matches this mint are returned.
+   * @param {Opt} [opt] - An optional object that contains additional options for the function.
+   * @param {GetPositionsOpt} [getPositionsOpt] - Optional settings for chunked position fetching
+   * @returns The function `getPositionsByUserAndTokenAddress` returns a `Promise` that resolves to a
+   * `Map` object. The `Map` object contains key-value pairs, where the key is a string representing the
+   * LB Pair account, and the value is an object of PositionInfo. Only pools containing `tokenMint` are
+   * included.
+   */
+  static async getPositionsByUserAndTokenAddress(
+    connection: Connection,
+    userPubKey: PublicKey,
+    tokenMint: PublicKey,
+    opt?: Opt,
+    getPositionsOpt?: GetPositionsOpt,
+  ): Promise<Map<string, PositionInfo>> {
+    // Position accounts only store the lbPair and owner (no token mints), so we cannot
+    // filter positions by token mint directly. Instead we resolve the user's positions
+    // (which decodes each lbPair) and then keep only the pools that contain the token.
+    const allPositions = await DLMM.getAllLbPairPositionsByUser(
+      connection,
+      userPubKey,
+      opt,
+      getPositionsOpt,
+    );
+
+    const targetMint = tokenMint.toBase58();
+    const filteredPositions = new Map<string, PositionInfo>();
+
+    for (const [lbPairKey, positionInfo] of allPositions) {
+      const tokenXMint = positionInfo.lbPair.tokenXMint.toBase58();
+      const tokenYMint = positionInfo.lbPair.tokenYMint.toBase58();
+
+      if (tokenXMint === targetMint || tokenYMint === targetMint) {
+        filteredPositions.set(lbPairKey, positionInfo);
+      }
+    }
+
+    return filteredPositions;
+  }
+
+  /**
+   * The function `getLimitOrdersByUserAndTokenAddress` retrieves all of a user's limit orders across
+   * every DLMM pool that includes the given token mint as either the X or Y token.
+   * @param {Connection} connection - The `connection` parameter is an instance of the `Connection`
+   * class, which represents the connection to the Solana blockchain.
+   * @param {PublicKey} userPubKey - The user's wallet public key.
+   * @param {PublicKey} tokenMint - The token mint used to filter pools. Only limit orders in pools
+   * whose `tokenXMint` or `tokenYMint` matches this mint are returned.
+   * @param {Opt} [opt] - An optional object that contains additional options for the function.
+   * @returns The function `getLimitOrdersByUserAndTokenAddress` returns a `Promise` that resolves to a
+   * `Map` object keyed by LB Pair account (base58), where each value is a `LimitOrderInfo` containing
+   * the LB pair state, token reserves, and the parsed limit orders for that pool.
+   */
+  static async getLimitOrdersByUserAndTokenAddress(
+    connection: Connection,
+    userPubKey: PublicKey,
+    tokenMint: PublicKey,
+    opt?: Opt,
+  ): Promise<Map<string, LimitOrderInfo>> {
+    const program = createProgram(connection, opt);
+
+    // Limit order accounts only store the lbPair and owner (no token mints), so we resolve the user's
+    // limit orders first, then keep only the ones whose pool contains the requested token mint.
+    const limitOrderAccounts = await chunkedGetProgramAccounts(
+      program.provider.connection,
+      program.programId,
+      [limitOrderFilter(), limitOrderOwnerFilter(userPubKey)],
+    );
+
+    const limitOrderWrappers: ILimitOrder[] = limitOrderAccounts.map(
+      ({ pubkey, account }) => wrapLimitOrder(program, pubkey, account),
+    );
+
+    if (limitOrderWrappers.length === 0) {
+      return new Map();
+    }
+
+    // Resolve the unique set of LB pairs the orders belong to, then decode them
+    const lbPairKeys = Array.from(
+      new Set(limitOrderWrappers.map((lo) => lo.lbPair().toBase58())),
+    ).map((key) => new PublicKey(key));
+
+    const lbPairAccInfos = await chunkedGetMultipleAccountInfos(
+      connection,
+      lbPairKeys,
+    );
+
+    const lbPairMap = new Map<string, LbPair>();
+    lbPairKeys.forEach((lbPairPubkey, i) => {
+      const accInfo = lbPairAccInfos[i];
+      if (!accInfo) {
+        throw new Error(`LB Pair account ${lbPairPubkey.toBase58()} not found`);
+      }
+      lbPairMap.set(
+        lbPairPubkey.toBase58(),
+        decodeAccount<LbPair>(program, "lbPair", accInfo.data),
+      );
+    });
+
+    // Keep only the pools that contain the requested token mint
+    const targetMint = tokenMint.toBase58();
+    const matchingLbPairKeys = lbPairKeys.filter((lbPairPubkey) => {
+      const lbPairState = lbPairMap.get(lbPairPubkey.toBase58());
+      return (
+        lbPairState.tokenXMint.toBase58() === targetMint ||
+        lbPairState.tokenYMint.toBase58() === targetMint
+      );
+    });
+
+    if (matchingLbPairKeys.length === 0) {
+      return new Map();
+    }
+
+    const matchingLbPairSet = new Set(
+      matchingLbPairKeys.map((key) => key.toBase58()),
+    );
+
+    const matchingLimitOrders = limitOrderWrappers.filter((lo) =>
+      matchingLbPairSet.has(lo.lbPair().toBase58()),
+    );
+
+    // Reserve + mint accounts for each matching pool (4 per pool), used to build TokenReserve
+    const reserveAndMintKeys = matchingLbPairKeys
+      .map((lbPairPubkey) => {
+        const { reserveX, reserveY, tokenXMint, tokenYMint } = lbPairMap.get(
+          lbPairPubkey.toBase58(),
+        );
+        return [reserveX, reserveY, tokenXMint, tokenYMint];
+      })
+      .flat();
+
+    // Bin arrays covered by the matching limit orders (needed to parse fill state)
+    const binArrayPubkeySet = new Set<string>();
+    matchingLimitOrders.forEach((lo) => {
+      lo.getBinArrayKeysCoverage(program.programId).forEach((key) => {
+        binArrayPubkeySet.add(key.toBase58());
+      });
+    });
+    const binArrayKeys = Array.from(binArrayPubkeySet).map(
+      (key) => new PublicKey(key),
+    );
+
+    const [clockAccInfo, ...rest] = await chunkedGetMultipleAccountInfos(
+      connection,
+      [SYSVAR_CLOCK_PUBKEY, ...binArrayKeys, ...reserveAndMintKeys],
+    );
+
+    const binArraysAccInfo = rest.slice(0, binArrayKeys.length);
+    const reserveAndMintAccInfo = rest.slice(binArrayKeys.length);
+
+    const clock: Clock = ClockLayout.decode(clockAccInfo.data);
+
+    const binArrayMap = new Map<string, BinArray>();
+    binArrayKeys.forEach((binArrayPubkey, i) => {
+      const accInfo = binArraysAccInfo[i];
+      if (accInfo) {
+        binArrayMap.set(
+          binArrayPubkey.toBase58(),
+          decodeAccount<BinArray>(program, "binArray", accInfo.data),
+        );
+      }
+    });
+
+    const lbPairTokenMap = new Map<
+      string,
+      { tokenX: TokenReserve; tokenY: TokenReserve; mintX: Mint; mintY: Mint }
+    >();
+
+    matchingLbPairKeys.forEach((lbPairPubkey, idx) => {
+      const index = idx * 4;
+      const reserveXAccount = reserveAndMintAccInfo[index];
+      const reserveYAccount = reserveAndMintAccInfo[index + 1];
+      const mintXAccount = reserveAndMintAccInfo[index + 2];
+      const mintYAccount = reserveAndMintAccInfo[index + 3];
+
+      if (!reserveXAccount || !reserveYAccount) {
+        throw new Error(
+          `Reserve account for LB Pair ${lbPairPubkey.toBase58()} not found`,
+        );
+      }
+      if (!mintXAccount || !mintYAccount) {
+        throw new Error(
+          `Mint account for LB Pair ${lbPairPubkey.toBase58()} not found`,
+        );
+      }
+
+      const lbPairState = lbPairMap.get(lbPairPubkey.toBase58());
+      const reserveAccX = AccountLayout.decode(reserveXAccount.data);
+      const reserveAccY = AccountLayout.decode(reserveYAccount.data);
+
+      const mintX = unpackMint(
+        reserveAccX.mint,
+        mintXAccount,
+        mintXAccount.owner,
+      );
+      const mintY = unpackMint(
+        reserveAccY.mint,
+        mintYAccount,
+        mintYAccount.owner,
+      );
+
+      const { tokenXProgram, tokenYProgram } = getTokenProgramId(lbPairState);
+
+      const tokenX: TokenReserve = {
+        publicKey: lbPairState.tokenXMint,
+        reserve: lbPairState.reserveX,
+        amount: reserveAccX.amount,
+        mint: mintX,
+        owner: tokenXProgram,
+        transferHookAccountMetas: [], // Not required for read-only limit order processing
+      };
+
+      const tokenY: TokenReserve = {
+        publicKey: lbPairState.tokenYMint,
+        reserve: lbPairState.reserveY,
+        amount: reserveAccY.amount,
+        mint: mintY,
+        owner: tokenYProgram,
+        transferHookAccountMetas: [], // Not required for read-only limit order processing
+      };
+
+      lbPairTokenMap.set(lbPairPubkey.toBase58(), {
+        tokenX,
+        tokenY,
+        mintX,
+        mintY,
+      });
+    });
+
+    const limitOrdersMap = new Map<string, LimitOrderInfo>();
+
+    for (const lo of matchingLimitOrders) {
+      const lbPairKey = lo.lbPair().toBase58();
+      const lbPairState = lbPairMap.get(lbPairKey);
+      const { tokenX, tokenY, mintX, mintY } = lbPairTokenMap.get(lbPairKey);
+
+      const parsedLo = lo.parseInfo(
+        program.programId,
+        lbPairState,
+        mintX,
+        mintY,
+        clock,
+        binArrayMap,
+      );
+
+      const entry: ParsedLimitOrderWithPubkey = {
+        publicKey: lo.address(),
+        limitOrderData: parsedLo,
+      };
+
+      const existing = limitOrdersMap.get(lbPairKey);
+      if (existing) {
+        existing.limitOrders.push(entry);
+      } else {
+        limitOrdersMap.set(lbPairKey, {
+          publicKey: lo.lbPair(),
+          lbPair: lbPairState,
+          tokenX,
+          tokenY,
+          limitOrders: [entry],
+        });
+      }
+    }
+
+    return limitOrdersMap;
   }
 
   public static getPricePerLamport(

--- a/ts-client/src/dlmm/index.ts
+++ b/ts-client/src/dlmm/index.ts
@@ -1195,9 +1195,6 @@ export class DLMM {
     opt?: Opt,
     getPositionsOpt?: GetPositionsOpt,
   ): Promise<Map<string, PositionInfo>> {
-    // Position accounts only store the lbPair and owner (no token mints), so we cannot
-    // filter positions by token mint directly. Instead we resolve the user's positions
-    // (which decodes each lbPair) and then keep only the pools that contain the token.
     const allPositions = await DLMM.getAllLbPairPositionsByUser(
       connection,
       userPubKey,
@@ -1241,8 +1238,6 @@ export class DLMM {
   ): Promise<Map<string, LimitOrderInfo>> {
     const program = createProgram(connection, opt);
 
-    // Limit order accounts only store the lbPair and owner (no token mints), so we resolve the user's
-    // limit orders first, then keep only the ones whose pool contains the requested token mint.
     const limitOrderAccounts = await chunkedGetProgramAccounts(
       program.provider.connection,
       program.programId,
@@ -1257,7 +1252,6 @@ export class DLMM {
       return new Map();
     }
 
-    // Resolve the unique set of LB pairs the orders belong to, then decode them
     const lbPairKeys = Array.from(
       new Set(limitOrderWrappers.map((lo) => lo.lbPair().toBase58())),
     ).map((key) => new PublicKey(key));
@@ -1279,7 +1273,6 @@ export class DLMM {
       );
     });
 
-    // Keep only the pools that contain the requested token mint
     const targetMint = tokenMint.toBase58();
     const matchingLbPairKeys = lbPairKeys.filter((lbPairPubkey) => {
       const lbPairState = lbPairMap.get(lbPairPubkey.toBase58());
@@ -1301,7 +1294,6 @@ export class DLMM {
       matchingLbPairSet.has(lo.lbPair().toBase58()),
     );
 
-    // Reserve + mint accounts for each matching pool (4 per pool), used to build TokenReserve
     const reserveAndMintKeys = matchingLbPairKeys
       .map((lbPairPubkey) => {
         const { reserveX, reserveY, tokenXMint, tokenYMint } = lbPairMap.get(
@@ -1311,7 +1303,6 @@ export class DLMM {
       })
       .flat();
 
-    // Bin arrays covered by the matching limit orders (needed to parse fill state)
     const binArrayPubkeySet = new Set<string>();
     matchingLimitOrders.forEach((lo) => {
       lo.getBinArrayKeysCoverage(program.programId).forEach((key) => {
@@ -1342,6 +1333,38 @@ export class DLMM {
         );
       }
     });
+
+    const seenMints = new Set<string>();
+    const mintsWithAccount = matchingLbPairKeys
+      .flatMap((lbPairPubkey, idx) => {
+        const { tokenXMint, tokenYMint } = lbPairMap.get(
+          lbPairPubkey.toBase58(),
+        );
+        const index = idx * 4;
+        return [
+          {
+            mintAddress: tokenXMint,
+            mintAccountInfo: reserveAndMintAccInfo[index + 2],
+          },
+          {
+            mintAddress: tokenYMint,
+            mintAccountInfo: reserveAndMintAccInfo[index + 3],
+          },
+        ];
+      })
+      .filter(({ mintAddress, mintAccountInfo }) => {
+        if (!mintAccountInfo || seenMints.has(mintAddress.toBase58())) {
+          return false;
+        }
+        seenMints.add(mintAddress.toBase58());
+        return true;
+      });
+
+    const mintHookAccountsMap =
+      await getMultipleMintsExtraAccountMetasForTransferHook(
+        connection,
+        mintsWithAccount,
+      );
 
     const lbPairTokenMap = new Map<
       string,
@@ -1389,7 +1412,8 @@ export class DLMM {
         amount: reserveAccX.amount,
         mint: mintX,
         owner: tokenXProgram,
-        transferHookAccountMetas: [], // Not required for read-only limit order processing
+        transferHookAccountMetas:
+          mintHookAccountsMap.get(lbPairState.tokenXMint.toBase58()) ?? [],
       };
 
       const tokenY: TokenReserve = {
@@ -1398,7 +1422,8 @@ export class DLMM {
         amount: reserveAccY.amount,
         mint: mintY,
         owner: tokenYProgram,
-        transferHookAccountMetas: [], // Not required for read-only limit order processing
+        transferHookAccountMetas:
+          mintHookAccountsMap.get(lbPairState.tokenYMint.toBase58()) ?? [],
       };
 
       lbPairTokenMap.set(lbPairPubkey.toBase58(), {

--- a/ts-client/src/dlmm/types/index.ts
+++ b/ts-client/src/dlmm/types/index.ts
@@ -137,6 +137,14 @@ export interface PositionInfo {
   lbPairPositionsData: Array<LbPosition>;
 }
 
+export interface LimitOrderInfo {
+  publicKey: PublicKey;
+  lbPair: LbPair;
+  tokenX: TokenReserve;
+  tokenY: TokenReserve;
+  limitOrders: Array<ParsedLimitOrderWithPubkey>;
+}
+
 export interface FeeInfo {
   baseFeeRatePercentage: Decimal;
   maxFeeRatePercentage: Decimal;

--- a/ts-client/src/test/sdk.test.ts
+++ b/ts-client/src/test/sdk.test.ts
@@ -1013,6 +1013,76 @@ describe("SDK test", () => {
     ).not.toBeUndefined();
   });
 
+  it("get user positions by token address", async () => {
+    const positionsByToken = await DLMM.getPositionsByUserAndTokenAddress(
+      connection,
+      adminKeypair.publicKey,
+      BTC,
+      {
+        cluster: "localhost",
+      },
+    );
+
+    // Pool containing BTC should be included
+    const positions = positionsByToken.get(lbPairPubkey.toBase58());
+    expect(positions).not.toBeUndefined();
+    expect(
+      positions.lbPairPositionsData.find(({ publicKey }) =>
+        publicKey.equals(positionKeypair.publicKey),
+      ),
+    ).not.toBeUndefined();
+
+    // Every returned pool must contain the requested token mint
+    for (const [, positionInfo] of positionsByToken) {
+      const containsToken =
+        positionInfo.lbPair.tokenXMint.equals(BTC) ||
+        positionInfo.lbPair.tokenYMint.equals(BTC);
+      expect(containsToken).toBe(true);
+    }
+
+    // A mint the user has no positions for should yield an empty map
+    const emptyPositions = await DLMM.getPositionsByUserAndTokenAddress(
+      connection,
+      adminKeypair.publicKey,
+      Keypair.generate().publicKey,
+      {
+        cluster: "localhost",
+      },
+    );
+    expect(emptyPositions.size).toBe(0);
+  });
+
+  it("get user limit orders by token address", async () => {
+    // Every returned pool must contain the requested token mint
+    const limitOrdersByToken = await DLMM.getLimitOrdersByUserAndTokenAddress(
+      connection,
+      adminKeypair.publicKey,
+      BTC,
+      {
+        cluster: "localhost",
+      },
+    );
+
+    for (const [, limitOrderInfo] of limitOrdersByToken) {
+      const containsToken =
+        limitOrderInfo.lbPair.tokenXMint.equals(BTC) ||
+        limitOrderInfo.lbPair.tokenYMint.equals(BTC);
+      expect(containsToken).toBe(true);
+      expect(Array.isArray(limitOrderInfo.limitOrders)).toBe(true);
+    }
+
+    // A mint the user has no limit orders for should yield an empty map
+    const emptyLimitOrders = await DLMM.getLimitOrdersByUserAndTokenAddress(
+      connection,
+      adminKeypair.publicKey,
+      Keypair.generate().publicKey,
+      {
+        cluster: "localhost",
+      },
+    );
+    expect(emptyLimitOrders.size).toBe(0);
+  });
+
   describe("getPositionsByUserAndLbPair with GetPositionsOpt", () => {
     const additionalPositions: PublicKey[] = [];
     const NUM_ADDITIONAL_POSITIONS = 4; // Create 4 more positions (total 5 with existing one)


### PR DESCRIPTION
### Added

- Added `getPositionsByUserAndTokenAddress` static method to retrieve a user's positions across all DLMM pools that contain a given token mint (as either `tokenXMint` or `tokenYMint`).
- Added `getLimitOrdersByUserAndTokenAddress` static method to retrieve a user's limit orders across all DLMM pools that contain a given token mint (as either `tokenXMint` or `tokenYMint`), grouped by LB pair. Also exported a new `LimitOrderInfo` type.