### PR TITLE
Fix Node ESM anchor bytes import

### DIFF
--- a/ts-client/src/dlmm/helpers/accountFilters.ts
+++ b/ts-client/src/dlmm/helpers/accountFilters.ts
@@ -1,5 +1,5 @@
 import { GetProgramAccountsFilter, PublicKey } from "@solana/web3.js";
-import { bs58 } from "@coral-xyz/anchor/dist/cjs/utils/bytes";
+import { bs58 } from "@coral-xyz/anchor/dist/cjs/utils/bytes/index.js";
 import BN from "bn.js";
 import { getAccountDiscriminator } from ".";
 

--- a/ts-client/src/examples/example.ts
+++ b/ts-client/src/examples/example.ts
@@ -6,7 +6,7 @@ import {
   TransactionMessage,
   VersionedTransaction,
 } from "@solana/web3.js";
-import { bs58 } from "@coral-xyz/anchor/dist/cjs/utils/bytes";
+import { bs58 } from "@coral-xyz/anchor/dist/cjs/utils/bytes/index.js";
 import { DLMM } from "../dlmm";
 import BN from "bn.js";
 import { BinLiquidity, LbPosition, StrategyType } from "../dlmm/types";


### PR DESCRIPTION
## Summary

Fixes Node ESM / NodeNext resolution for the DLMM SDK by changing the Anchor bytes import to an explicit file path.

The ESM bundle currently emits:

```ts
import { bs58 } from "@coral-xyz/anchor/dist/cjs/utils/bytes";
```

Node's ESM resolver rejects that directory import with `ERR_UNSUPPORTED_DIR_IMPORT`. This PR updates the source import to:

```ts
import { bs58 } from "@coral-xyz/anchor/dist/cjs/utils/bytes/index.js";
```

I also updated the matching example import.

## Verification

- `pnpm build`
- `node --input-type=module -e "import DLMM, { deriveCustomizablePermissionlessLbPair } from './dist/index.mjs'; console.log(typeof DLMM, typeof DLMM.create, typeof deriveCustomizablePermissionlessLbPair)"`
