### PR TITLE
fix: track first filled bin in exact out quote

### DIFF
--- a/ts-client/src/dlmm/index.ts
+++ b/ts-client/src/dlmm/index.ts
@@ -5346,7 +5346,7 @@ export class DLMM {
       currentTimestamp,
     );
 
-    let startBinId = activeId;
+    let startBinId: BN | null = outAmountLeft.isZero() ? activeId : null;
     let binArraysForSwap = new Map();
     let actualInAmount: BN = new BN(0);
     let feeAmount: BN = new BN(0);
@@ -5408,6 +5408,10 @@ export class DLMM {
             actualInAmount = actualInAmount.add(amountIn);
             feeAmount = feeAmount.add(fee);
             protocolFeeAmount = protocolFeeAmount.add(protocolFee);
+
+            if (startBinId === null) {
+              startBinId = activeId;
+            }
           }
         }
       }
@@ -5419,6 +5423,13 @@ export class DLMM {
           activeId = activeId.add(new BN(1));
         }
       }
+    }
+
+    if (startBinId === null) {
+      throw new DlmmSdkError(
+        "SWAP_QUOTE_INSUFFICIENT_LIQUIDITY",
+        "Insufficient liquidity",
+      );
     }
 
     const startPrice = getPriceOfBinByBinId(


### PR DESCRIPTION
Addresses #288.

`swapQuoteExactOut` initialized `startBinId` to the pool's active bin before walking liquidity. If the active bin had no matching output liquidity, the returned `startPrice` and derived `priceImpact` could be based on a bin that did not actually contribute to the quote.

This updates exact-out quote calculation to set `startBinId` only when a bin contributes non-zero `amountOut`, matching the intent of the exact-in quote path, which tracks the first filled bin.

For zero-output quotes, the previous active-bin behavior is preserved.

Verification:

- `tsc --noEmit --skipLibCheck --esModuleInterop --resolveJsonModule --moduleResolution node --module commonjs --target ESNext src/dlmm/index.ts`