### PR TITLE
[TESTING] feat(ts-client): Token-2022 ScaledUiAmount support

### DIFF
--- a/ts-client/src/dlmm/helpers/binArray.ts
+++ b/ts-client/src/dlmm/helpers/binArray.ts
@@ -1,5 +1,6 @@
 import { BN } from "@coral-xyz/anchor";
 import { AccountMeta, PublicKey } from "@solana/web3.js";
+import Decimal from "decimal.js";
 import {
   BIN_ARRAY_BITMAP_SIZE,
   DEFAULT_BIN_PER_POSITION,
@@ -377,6 +378,8 @@ export function* enumerateBins(
   quoteTokenDecimal: number,
   version: number,
   lbPair: LbPair,
+  baseMultiplier: Decimal = new Decimal(1),
+  quoteMultiplier: Decimal = new Decimal(1),
 ) {
   for (
     let currentBinId = lowerBinId;
@@ -393,6 +396,8 @@ export function* enumerateBins(
         quoteTokenDecimal,
         version,
         lbPair,
+        baseMultiplier,
+        quoteMultiplier,
       );
     } else {
       yield BinLiquidity.empty(
@@ -401,6 +406,8 @@ export function* enumerateBins(
         baseTokenDecimal,
         quoteTokenDecimal,
         version,
+        baseMultiplier,
+        quoteMultiplier,
       );
     }
   }

--- a/ts-client/src/dlmm/helpers/oracle/wrapper.ts
+++ b/ts-client/src/dlmm/helpers/oracle/wrapper.ts
@@ -82,6 +82,8 @@ export function wrapOracle(
   baseTokenDecimals: number,
   quoteTokenDecimals: number,
   program: Program<LbClmm>,
+  baseMultiplier: Decimal = new Decimal(1),
+  quoteMultiplier: Decimal = new Decimal(1),
 ) {
   const oracleBaseData = data.subarray(0, ORACLE_METADATA_SIZE);
   const oracleState: Oracle = decodeAccount(program, "oracle", oracleBaseData);
@@ -125,6 +127,8 @@ export function wrapOracle(
     currentActiveBinId,
     baseTokenDecimals,
     quoteTokenDecimals,
+    baseMultiplier,
+    quoteMultiplier,
   );
 }
 
@@ -137,6 +141,8 @@ export class DynamicOracle implements IDynamicOracle {
     private currentActiveBinId: BN,
     private baseTokenDecimals: number,
     private quoteTokenDecimals: number,
+    private baseMultiplier: Decimal = new Decimal(1),
+    private quoteMultiplier: Decimal = new Decimal(1),
   ) {}
 
   nextIndex(): number {
@@ -284,12 +290,19 @@ export class DynamicOracle implements IDynamicOracle {
     );
     const quoteAdjustment = new Decimal(10).pow(this.quoteTokenDecimals);
 
+    // Scale in place by the Token-2022 ScaledUiAmount multipliers (quote / base).
+    // No-op when neither mint has the extension.
+    const priceScaleFactor = this.baseMultiplier.isZero()
+      ? new Decimal(1)
+      : this.quoteMultiplier.div(this.baseMultiplier);
+
     return {
       value: result.value
         .mul(uiMultiplier)
         .mul(quoteAdjustment)
         .floor()
-        .div(quoteAdjustment),
+        .div(quoteAdjustment)
+        .mul(priceScaleFactor),
       duration: result.duration,
     };
   }

--- a/ts-client/src/dlmm/helpers/token_2022.ts
+++ b/ts-client/src/dlmm/helpers/token_2022.ts
@@ -3,7 +3,6 @@ import {
   calculateFee,
   createTransferCheckedInstruction,
   getEpochFee,
-  getScaledUiAmountConfig,
   getTransferFeeConfig,
   getTransferHook,
   MAX_FEE_BASIS_POINTS,
@@ -236,6 +235,11 @@ export function calculateTransferFeeExcludedAmount(
   };
 }
 
+/** Token-2022 ScaledUiAmount extension discriminator in the mint TLV data. */
+const SCALED_UI_AMOUNT_CONFIG_EXTENSION_TYPE = 25;
+/** Byte size of the ScaledUiAmount config: authority(32) + multiplier(8) + timestamp(8) + newMultiplier(8). */
+const SCALED_UI_AMOUNT_CONFIG_SIZE = 56;
+
 /**
  * Returns the Token-2022 ScaledUiAmount extension multiplier for a mint at the
  * given unix timestamp. Returns 1 when the mint has no ScaledUiAmount extension,
@@ -249,18 +253,46 @@ export function getScaledUiAmountMultiplier(
   mint: Mint,
   unixTimestamp: number
 ): Decimal {
-  const config = getScaledUiAmountConfig(mint);
-
-  if (config === null) {
+  const tlvData = mint.tlvData;
+  if (!tlvData || tlvData.length === 0) {
     return new Decimal(1);
   }
 
-  const effectiveMultiplier =
-    unixTimestamp >= Number(config.newMultiplierEffectiveTimestamp)
-      ? config.newMultiplier
-      : config.multiplier;
+  // Walk the mint's TLV entries (type: u16 LE, length: u16 LE, then `length`
+  // bytes of data) and decode the ScaledUiAmount config directly. Decoding it
+  // here — rather than importing `getScaledUiAmountConfig` from
+  // @solana/spl-token — keeps this working regardless of the installed
+  // spl-token version (the getter only exists in newer 0.4.x releases).
+  let offset = 0;
+  while (offset + 4 <= tlvData.length) {
+    const extensionType = tlvData.readUInt16LE(offset);
+    const length = tlvData.readUInt16LE(offset + 2);
+    const dataStart = offset + 4;
 
-  return new Decimal(effectiveMultiplier);
+    if (
+      extensionType === SCALED_UI_AMOUNT_CONFIG_EXTENSION_TYPE &&
+      dataStart + SCALED_UI_AMOUNT_CONFIG_SIZE <= tlvData.length
+    ) {
+      // Layout: authority(32) | multiplier f64(8) |
+      //         newMultiplierEffectiveTimestamp u64(8) | newMultiplier f64(8)
+      const multiplier = tlvData.readDoubleLE(dataStart + 32);
+      const newMultiplierEffectiveTimestamp = tlvData.readBigUInt64LE(
+        dataStart + 40
+      );
+      const newMultiplier = tlvData.readDoubleLE(dataStart + 48);
+
+      const effectiveMultiplier =
+        BigInt(unixTimestamp) >= newMultiplierEffectiveTimestamp
+          ? newMultiplier
+          : multiplier;
+
+      return new Decimal(effectiveMultiplier);
+    }
+
+    offset = dataStart + length;
+  }
+
+  return new Decimal(1);
 }
 
 /**

--- a/ts-client/src/dlmm/helpers/token_2022.ts
+++ b/ts-client/src/dlmm/helpers/token_2022.ts
@@ -3,6 +3,7 @@ import {
   calculateFee,
   createTransferCheckedInstruction,
   getEpochFee,
+  getScaledUiAmountConfig,
   getTransferFeeConfig,
   getTransferHook,
   MAX_FEE_BASIS_POINTS,
@@ -19,6 +20,7 @@ import {
   PublicKey,
 } from "@solana/web3.js";
 import BN from "bn.js";
+import Decimal from "decimal.js";
 
 export async function getMultipleMintsExtraAccountMetasForTransferHook(
   connection: Connection,
@@ -232,4 +234,68 @@ export function calculateTransferFeeExcludedAmount(
     amount: transferFeeExcludedAmount,
     transferFee: new BN(transferFee.toString()),
   };
+}
+
+/**
+ * Returns the Token-2022 ScaledUiAmount extension multiplier for a mint at the
+ * given unix timestamp. Returns 1 when the mint has no ScaledUiAmount extension,
+ * so callers can multiply unconditionally.
+ *
+ * The extension supports a scheduled multiplier switch: once the current time
+ * reaches `newMultiplierEffectiveTimestamp`, `newMultiplier` takes over from
+ * `multiplier`. This mirrors the on-chain UI amount computation.
+ */
+export function getScaledUiAmountMultiplier(
+  mint: Mint,
+  unixTimestamp: number
+): Decimal {
+  const config = getScaledUiAmountConfig(mint);
+
+  if (config === null) {
+    return new Decimal(1);
+  }
+
+  const effectiveMultiplier =
+    unixTimestamp >= Number(config.newMultiplierEffectiveTimestamp)
+      ? config.newMultiplier
+      : config.multiplier;
+
+  return new Decimal(effectiveMultiplier);
+}
+
+/**
+ * Scales a raw token amount by a ScaledUiAmount multiplier, flooring to the
+ * nearest integer lamport. Returns the amount unchanged when the multiplier is 1.
+ */
+export function scaleAmountByMultiplier(amount: BN, multiplier: Decimal): BN {
+  if (multiplier.eq(1)) {
+    return amount;
+  }
+
+  return new BN(
+    new Decimal(amount.toString()).mul(multiplier).floor().toString()
+  );
+}
+
+/**
+ * Scales a decimals-adjusted price (`pricePerToken`, expressed as quote per base)
+ * by the ScaledUiAmount multipliers of both mints:
+ * `pricePerToken * quoteMultiplier / baseMultiplier`.
+ *
+ * Falls back to the unscaled price when `baseMultiplier` is zero (a pathological
+ * mint configuration) to avoid producing `Infinity`.
+ */
+export function scalePricePerToken(
+  pricePerToken: string,
+  baseMultiplier: Decimal,
+  quoteMultiplier: Decimal
+): string {
+  if (baseMultiplier.isZero()) {
+    return pricePerToken;
+  }
+
+  return new Decimal(pricePerToken)
+    .mul(quoteMultiplier)
+    .div(baseMultiplier)
+    .toString();
 }

--- a/ts-client/src/dlmm/index.ts
+++ b/ts-client/src/dlmm/index.ts
@@ -166,6 +166,8 @@ import {
   calculateTransferFeeIncludedAmount,
   getExtraAccountMetasForTransferHook,
   getMultipleMintsExtraAccountMetasForTransferHook,
+  getScaledUiAmountMultiplier,
+  scaleAmountByMultiplier,
 } from "./helpers/token_2022";
 import {
   ActionType,
@@ -2650,12 +2652,21 @@ export class DLMM {
    * @returns {string} real price of bin
    */
   public fromPricePerLamport(pricePerLamport: number): string {
+    const nowTs = this.clock.unixTimestamp.toNumber();
+    const baseMultiplier = getScaledUiAmountMultiplier(this.tokenX.mint, nowTs);
+    const quoteMultiplier = getScaledUiAmountMultiplier(this.tokenY.mint, nowTs);
+    // Token-2022 ScaledUiAmount price adjustment (quote / base). No-op without the extension.
+    const priceScaleFactor = baseMultiplier.isZero()
+      ? new Decimal(1)
+      : quoteMultiplier.div(baseMultiplier);
+
     return new Decimal(pricePerLamport)
       .div(
         new Decimal(
           10 ** (this.tokenY.mint.decimals - this.tokenX.mint.decimals),
         ),
       )
+      .mul(priceScaleFactor)
       .toString();
   }
 
@@ -5755,6 +5766,21 @@ export class DLMM {
       .mul(new BN(BASIS_POINT_MAX).sub(allowedSlippage))
       .div(new BN(BASIS_POINT_MAX));
 
+    // Scale the display end price by the Token-2022 ScaledUiAmount multipliers
+    // (quote / base). Amounts are left raw — they feed the on-chain swap instruction.
+    const nowTs = this.clock.unixTimestamp.toNumber();
+    const endPriceBaseMultiplier = getScaledUiAmountMultiplier(
+      this.tokenX.mint,
+      nowTs,
+    );
+    const endPriceQuoteMultiplier = getScaledUiAmountMultiplier(
+      this.tokenY.mint,
+      nowTs,
+    );
+    const scaledEndPrice = endPriceBaseMultiplier.isZero()
+      ? endPrice
+      : endPrice.mul(endPriceQuoteMultiplier).div(endPriceBaseMultiplier);
+
     return {
       consumedInAmount: transferFeeIncludedInAmount,
       outAmount: transferFeeExcludedAmountOut,
@@ -5763,7 +5789,7 @@ export class DLMM {
       minOutAmount,
       priceImpact,
       binArraysPubkey,
-      endPrice,
+      endPrice: scaledEndPrice,
       feeOnInput,
     };
   }
@@ -8858,6 +8884,19 @@ export class DLMM {
 
     const feeOwner = position.feeOwner();
 
+    // Token-2022 ScaledUiAmount multipliers (1 when the mint has no extension).
+    // Bin amounts/price come back already scaled from getBinsBetweenLowerAndUpperBound,
+    // so position/total amounts inherit the scale; fees and rewards are scaled here.
+    const nowTs = clock.unixTimestamp.toNumber();
+    const baseMultiplier = getScaledUiAmountMultiplier(baseMint, nowTs);
+    const quoteMultiplier = getScaledUiAmountMultiplier(quoteMint, nowTs);
+    const rewardOneMultiplier = rewardMint0
+      ? getScaledUiAmountMultiplier(rewardMint0, nowTs)
+      : new Decimal(1);
+    const rewardTwoMultiplier = rewardMint1
+      ? getScaledUiAmountMultiplier(rewardMint1, nowTs)
+      : new Decimal(1);
+
     const bins = this.getBinsBetweenLowerAndUpperBound(
       lbPairKey,
       lbPair,
@@ -8867,6 +8906,8 @@ export class DLMM {
       quoteMint.decimals,
       binArrayMap,
       program.programId,
+      baseMultiplier,
+      quoteMultiplier,
     );
 
     if (!bins.length) return null;
@@ -8990,10 +9031,19 @@ export class DLMM {
         positionLiquidity: posShare.toString(),
         positionXAmount: positionXAmount.toString(),
         positionYAmount: positionYAmount.toString(),
-        positionFeeXAmount: claimableFeeX.toString(),
-        positionFeeYAmount: claimableFeeY.toString(),
-        positionRewardAmount: claimableRewardsInBin.map((amount) =>
-          amount.toString(),
+        positionFeeXAmount: scaleAmountByMultiplier(
+          claimableFeeX,
+          baseMultiplier,
+        ).toString(),
+        positionFeeYAmount: scaleAmountByMultiplier(
+          claimableFeeY,
+          quoteMultiplier,
+        ).toString(),
+        positionRewardAmount: claimableRewardsInBin.map((amount, j) =>
+          scaleAmountByMultiplier(
+            amount,
+            j === 0 ? rewardOneMultiplier : rewardTwoMultiplier,
+          ).toString(),
         ),
       });
     });
@@ -9047,25 +9097,44 @@ export class DLMM {
     ).amount;
 
     return {
+      // totals inherit the scale from the already-scaled bin amounts
       totalXAmount: totalXAmount.toString(),
       totalYAmount: totalYAmount.toString(),
       positionBinData: positionData,
       lastUpdatedAt,
       lowerBinId: lowerBinId.toNumber(),
       upperBinId: upperBinId.toNumber(),
-      feeX,
-      feeY,
-      rewardOne,
-      rewardTwo,
+      feeX: scaleAmountByMultiplier(feeX, baseMultiplier),
+      feeY: scaleAmountByMultiplier(feeY, quoteMultiplier),
+      rewardOne: scaleAmountByMultiplier(rewardOne, rewardOneMultiplier),
+      rewardTwo: scaleAmountByMultiplier(rewardTwo, rewardTwoMultiplier),
       feeOwner,
-      totalClaimedFeeXAmount,
-      totalClaimedFeeYAmount,
+      totalClaimedFeeXAmount: scaleAmountByMultiplier(
+        totalClaimedFeeXAmount,
+        baseMultiplier,
+      ),
+      totalClaimedFeeYAmount: scaleAmountByMultiplier(
+        totalClaimedFeeYAmount,
+        quoteMultiplier,
+      ),
       totalXAmountExcludeTransferFee,
       totalYAmountExcludeTransferFee,
-      rewardOneExcludeTransferFee,
-      rewardTwoExcludeTransferFee,
-      feeXExcludeTransferFee,
-      feeYExcludeTransferFee,
+      rewardOneExcludeTransferFee: scaleAmountByMultiplier(
+        rewardOneExcludeTransferFee,
+        rewardOneMultiplier,
+      ),
+      rewardTwoExcludeTransferFee: scaleAmountByMultiplier(
+        rewardTwoExcludeTransferFee,
+        rewardTwoMultiplier,
+      ),
+      feeXExcludeTransferFee: scaleAmountByMultiplier(
+        feeXExcludeTransferFee,
+        baseMultiplier,
+      ),
+      feeYExcludeTransferFee: scaleAmountByMultiplier(
+        feeYExcludeTransferFee,
+        quoteMultiplier,
+      ),
       owner: position.owner(),
     };
   }
@@ -9079,6 +9148,8 @@ export class DLMM {
     quoteTokenDecimal: number,
     binArrayMap: Map<String, BinArray>,
     programId: PublicKey,
+    baseMultiplier: Decimal = new Decimal(1),
+    quoteMultiplier: Decimal = new Decimal(1),
   ): BinLiquidity[] {
     const lowerBinArrayIndex = binIdToBinArrayIndex(new BN(lowerBinId));
     const upperBinArrayIndex = binIdToBinArrayIndex(new BN(upperBinId));
@@ -9114,6 +9185,8 @@ export class DLMM {
                 baseTokenDecimal,
                 quoteTokenDecimal,
                 BIN_ARRAY_DEFAULT_VERSION,
+                baseMultiplier,
+                quoteMultiplier,
               ),
             );
           } else {
@@ -9128,6 +9201,8 @@ export class DLMM {
                 quoteTokenDecimal,
                 binArray.version,
                 lbPair,
+                baseMultiplier,
+                quoteMultiplier,
               ),
             );
           }
@@ -9214,6 +9289,16 @@ export class DLMM {
     const version =
       binArrays.find((binArray) => binArray != null)?.version ?? 1;
 
+    const nowTs = this.clock.unixTimestamp.toNumber();
+    const baseMultiplier = getScaledUiAmountMultiplier(
+      this.tokenX.mint,
+      nowTs,
+    );
+    const quoteMultiplier = getScaledUiAmountMultiplier(
+      this.tokenY.mint,
+      nowTs,
+    );
+
     return Array.from(
       enumerateBins(
         binsById,
@@ -9224,6 +9309,8 @@ export class DLMM {
         quoteTokenDecimal,
         version,
         this.lbPair,
+        baseMultiplier,
+        quoteMultiplier,
       ),
     );
   }
@@ -9591,6 +9678,8 @@ export class DLMM {
       lbPairAccountInfo.data,
     );
 
+    const nowTs = this.clock.unixTimestamp.toNumber();
+
     return wrapOracle(
       oracleAddress,
       oracleAccountInfo.data,
@@ -9599,6 +9688,8 @@ export class DLMM {
       this.tokenX.mint.decimals,
       this.tokenY.mint.decimals,
       this.program,
+      getScaledUiAmountMultiplier(this.tokenX.mint, nowTs),
+      getScaledUiAmountMultiplier(this.tokenY.mint, nowTs),
     );
   }
 

--- a/ts-client/src/dlmm/types/index.ts
+++ b/ts-client/src/dlmm/types/index.ts
@@ -10,6 +10,8 @@ import {
   decodeRewardPerTokenStored,
   getPriceOfBinByBinId,
   isSupportLimitOrder,
+  scaleAmountByMultiplier,
+  scalePricePerToken,
 } from "../helpers";
 import {
   AccountInfo,
@@ -304,16 +306,24 @@ export module BinLiquidity {
     quoteTokenDecimal: number,
     version: number,
     lbPair: LbPair,
+    baseMultiplier: Decimal = new Decimal(1),
+    quoteMultiplier: Decimal = new Decimal(1),
   ): BinLiquidity {
     const pricePerLamport = getPriceOfBinByBinId(binId, binStep).toString();
     const supportLimitOrder = isSupportLimitOrder(lbPair);
 
-    const xAmount = bin.amountX;
-    const yAmount = bin.amountY;
+    // Amounts and price are scaled in place by the Token-2022 ScaledUiAmount
+    // multipliers (base for X, quote for Y). No-op when the mint has no extension.
+    const xAmount = scaleAmountByMultiplier(bin.amountX, baseMultiplier);
+    const yAmount = scaleAmountByMultiplier(bin.amountY, quoteMultiplier);
     const supply = bin.liquiditySupply;
-    const pricePerToken = new Decimal(pricePerLamport)
-      .mul(new Decimal(10 ** (baseTokenDecimal - quoteTokenDecimal)))
-      .toString();
+    const pricePerToken = scalePricePerToken(
+      new Decimal(pricePerLamport)
+        .mul(new Decimal(10 ** (baseTokenDecimal - quoteTokenDecimal)))
+        .toString(),
+      baseMultiplier,
+      quoteMultiplier,
+    );
     const feeAmountXPerTokenStored = bin.feeAmountXPerTokenStored;
     const feeAmountYPerTokenStored = bin.feeAmountYPerTokenStored;
 
@@ -370,6 +380,8 @@ export module BinLiquidity {
     baseTokenDecimal: number,
     quoteTokenDecimal: number,
     version: number,
+    baseMultiplier: Decimal = new Decimal(1),
+    quoteMultiplier: Decimal = new Decimal(1),
   ): BinLiquidity {
     const pricePerLamport = getPriceOfBinByBinId(binId, binStep).toString();
 
@@ -380,9 +392,13 @@ export module BinLiquidity {
       supply: new BN(0),
       price: pricePerLamport,
       version,
-      pricePerToken: new Decimal(pricePerLamport)
-        .mul(new Decimal(10 ** (baseTokenDecimal - quoteTokenDecimal)))
-        .toString(),
+      pricePerToken: scalePricePerToken(
+        new Decimal(pricePerLamport)
+          .mul(new Decimal(10 ** (baseTokenDecimal - quoteTokenDecimal)))
+          .toString(),
+        baseMultiplier,
+        quoteMultiplier,
+      ),
       feeAmountXPerTokenStored: new BN(0),
       feeAmountYPerTokenStored: new BN(0),
       rewardPerTokenStored: [new BN(0), new BN(0)],


### PR DESCRIPTION
## Support Token-2022 ScaledUiAmount

### The problem
Some Token-2022 tokens have a **ScaledUiAmount** setting. It holds a `multiplier` that changes the token's real display value. The SDK only adjusted for decimals, so it showed the wrong prices and amounts for these tokens.

### The fix
Multiply the prices and amounts by that multiplier before returning them.

> We change the values **on the fields that already exist** — no new fields, no changed function signatures. Tokens without the setting use a multiplier of `1`, so nothing changes for them. Safe to use everywhere.

The multiplier can change over time. It switches to `newMultiplier` once `clock.unixTimestamp` reaches `newMultiplierEffectiveTimestamp`. No extra network calls — we already have the mints and the clock.

### What gets scaled

| Field / method | Type | Scaled by |
|---|---|---|
| `BinLiquidity.pricePerToken` | price | `quote / base` |
| `fromPricePerLamport` | price | `quote / base` |
| oracle TWAP (`getUiPriceByTime`) | price | `quote / base` |
| `SwapQuote.endPrice` | price (display) | `quote / base` |
| `BinLiquidity.xAmount` / `yAmount` | amount | owning token |
| `PositionData` totals / fees / rewards / claimed | amount | owning token |
| `*ExcludeTransferFee` variants | amount | owning token |

### What stays raw (on-chain math)

| Field / method | Why |
|---|---|
| `SwapQuote.outAmount` / `minOutAmount` / `consumedInAmount` / `fee` | feeds the swap transaction |
| `getPriceOfBinByBinId`, `getBinFromBinArray` | shared low-level primitives |
| `priceImpact` | ratio — multiplier cancels out |

Scaling these would break swaps and liquidity math. Scaling lives only in the display wrappers.

### What this touches in the monorepo

| Package | Touched? |
|---|---|
| `ts-client` (`@meteora-ag/dlmm`) | ✅ only this package |
| `commons`, `cli` (Rust program) | ❌ no |
| `python-client` | ❌ no |
| `market_making` | ❌ no |

Files changed (all under `ts-client/src/dlmm/`):

| File | Change |
|---|---|
| `helpers/token_2022.ts` | new decode + scale helpers |
| `helpers/binArray.ts` | thread multipliers into bins |
| `helpers/oracle/wrapper.ts` | scale oracle price |
| `types/index.ts` | scale in `BinLiquidity` |
| `index.ts` | fetch multipliers, apply at call sites |

### New helpers (`helpers/token_2022.ts`)
- `getScaledUiAmountMultiplier(mint, ts)` — reads the setting straight from the mint's raw bytes (works on any spl-token version), applies the time switch, returns `1` if absent.
- `scaleAmountByMultiplier(amount, mult)` — multiplies and rounds down; no-op at `1`.
- `scalePricePerToken(price, base, quote)` — multiplies by `quote / base`; returns price unchanged if `base` is `0`.

### Note for reviewers
We change the returned values in place. Another option: keep the raw values and add new `scaled*` fields beside them. Happy to switch if preferred.

### Testing
`tsc --noEmit` and `tsup` both pass. Token pairs without the setting return the same values as before. A test with a real ScaledUiAmount token will come later.