### PR TITLE
Fix spot distribution dropping the bps rounding remainder

### DIFF
--- a/ts-client/src/dlmm/helpers/weight.ts
+++ b/ts-client/src/dlmm/helpers/weight.ts
@@ -138,7 +138,7 @@ export function calculateSpotDistribution(
     const { div: dist, mod: rem } = new BN(10_000).divmod(
       new BN(binIds.length)
     );
-    const loss = rem.isZero() ? new BN(0) : new BN(1);
+    const loss = rem;
 
     const distributions =
       binIds[0] < activeBin
@@ -155,11 +155,13 @@ export function calculateSpotDistribution(
 
     // Add the loss to the left most bin
     if (binIds[0] < activeBin) {
-      distributions[0].yAmountBpsOfTotal.add(loss);
+      distributions[0].yAmountBpsOfTotal =
+        distributions[0].yAmountBpsOfTotal.add(loss);
     }
     // Add the loss to the right most bin
     else {
-      distributions[binIds.length - 1].xAmountBpsOfTotal.add(loss);
+      distributions[binIds.length - 1].xAmountBpsOfTotal =
+        distributions[binIds.length - 1].xAmountBpsOfTotal.add(loss);
     }
 
     return distributions;

--- a/ts-client/src/test/calculate_distribution.test.ts
+++ b/ts-client/src/test/calculate_distribution.test.ts
@@ -195,6 +195,28 @@ describe("calculate_distribution", () => {
   });
 
   describe("spot distribution", () => {
+    test("returns a distribution summing to 10000 when the active bin is outside the range", () => {
+      // Bid side: every bin sits below the active bin, remainder of 1 bps.
+      const bid = calculateSpotDistribution(100, [50, 51, 52]);
+      const bidX = bid.reduce((a, d) => a + d.xAmountBpsOfTotal.toNumber(), 0);
+      const bidY = bid.reduce((a, d) => a + d.yAmountBpsOfTotal.toNumber(), 0);
+      expect(bidX).toBe(0);
+      expect(bidY).toBe(10_000);
+
+      // Larger remainder (10000 % 7 === 4): the whole remainder must go back to
+      // the edge bin, not a single bps.
+      const bid7 = calculateSpotDistribution(100, [50, 51, 52, 53, 54, 55, 56]);
+      const bid7Y = bid7.reduce((a, d) => a + d.yAmountBpsOfTotal.toNumber(), 0);
+      expect(bid7Y).toBe(10_000);
+
+      // Ask side: every bin sits above the active bin.
+      const ask = calculateSpotDistribution(100, [150, 151, 152]);
+      const askX = ask.reduce((a, d) => a + d.xAmountBpsOfTotal.toNumber(), 0);
+      const askY = ask.reduce((a, d) => a + d.yAmountBpsOfTotal.toNumber(), 0);
+      expect(askX).toBe(10_000);
+      expect(askY).toBe(0);
+    });
+
     test("should return correct distribution with equal delta", () => {
       const binIds = [1, 2, 3, 4, 5];
       const activeBin = 3;


### PR DESCRIPTION
## What

`calculateSpotDistribution` returns a distribution that sums to less than 10000 bps when the active bin is outside the requested range. Each side should sum to exactly 10000 (100%), but the rounding remainder is dropped.

## Why

Two things go wrong in the `!binIds.includes(activeBin)` branch:

```ts
const loss = rem.isZero() ? new BN(0) : new BN(1);
// ...
distributions[0].yAmountBpsOfTotal.add(loss);
```

- `bn.js` `.add()` is not in place, it returns a new BN, and the result is discarded, so the compensation is a no-op. The sibling helper `computeAllocationBps` in the same file assigns the result (`x = x.add(pLoss)`); only this branch drops it.
- `loss` is also clamped to `1` rather than the full remainder `rem`, so even with the assignment it would only add a single bps.

With `n` bins the sum lands at `10000 - rem`:

- `[50, 51, 52]` at active bin 100: each bin 3333, total 9999
- `[50, 51, 52, 53, 54, 55, 56]` (7 bins): each bin 1428, total 9996

## Change

Use the full remainder and assign the result, mirroring `computeAllocationBps`, so each side sums to exactly 10000. Added a test for the active-bin-outside-range branch (not covered by the existing spot tests) across bid, ask, and a remainder greater than one.
